### PR TITLE
Add timeout for windows job and step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: windows-2022
+    timeout-minutes: 20
 
     steps:
     - name: Setup Visual Studio Development Environment
@@ -24,4 +25,5 @@ jobs:
 
     - name: Test
       run: swift test --disable-keychain --skip-build
+      timeout-minutes: 10
 


### PR DESCRIPTION
'swift test' is hanging for hours. While we identify the reason, adding
a safeguard so that we are not billed for many hours on each test run.
