### PR TITLE
GHA: bump Swift snapshot to 2023-05-20-a

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       uses: compnerd/gha-setup-swift@main
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2023-02-27-a
+        tag: DEVELOPMENT-SNAPSHOT-2023-05-20-a
 
     - name: Check out repository code
       uses: actions/checkout@v3


### PR DESCRIPTION
Update the toolchain snapshot to a more recent release which contains @fischman-bcny's change for Foundation's runloop monitoring for NSProcess.

Fixes: WIN-576