### PR TITLE
Add unit tests for the way API usage maps to WebDriver requests

### DIFF
--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WebDriver
+
+/// Tests how usage of high-level Session/Element APIs map to lower-level requests
+class APIToRequestMappingTests : XCTestCase {
+    func testSessionAndElement() throws {
+        let mockWebDriver = MockWebDriver()
+        let session = Session(in: mockWebDriver, id: "mySession")
+        XCTAssertEqual(session.id, "mySession")
+
+        mockWebDriver.expect(path: "session/mySession/title", method: .get) { "mySession.title" }
+        XCTAssertEqual(session.title, "mySession.title")
+
+        struct ElementResponseValue : Encodable {
+            var ELEMENT: String
+        }
+
+        // TODO: assert that the request has expected values 
+        mockWebDriver.expect(path: "session/mySession/element", method: .post) { ElementResponseValue(ELEMENT: "myElement") }
+        let element = session.findElement(byName: "myElement.name")!
+
+        mockWebDriver.expect(path: "session/mySession/element/myElement/text", method: .get) { "myElement.text" }
+        XCTAssertEqual(element.text, "myElement.text")
+
+        mockWebDriver.expect(path: "session/mySession/element/myElement/click", method: .post)
+        element.click()
+
+        // Account for session deinitializer
+        mockWebDriver.expect(path: "session/mySession", method: .delete)
+    }
+}

--- a/Tests/UnitTests/MockWebDriver.swift
+++ b/Tests/UnitTests/MockWebDriver.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import WebDriver
+
+/// A mock WebDriver implementation which can be configured
+/// to expect certain requests and fail if they don't match.
+class MockWebDriver: WebDriver {
+    struct Expectation {
+        let path: String
+        let method: HTTPMethod
+        let handler: () -> Data?
+    }
+
+    var expectations: [Expectation] = []
+
+    deinit {
+        // We should have met all of our expectations
+        XCTAssertEqual(expectations.count, 0)
+    }
+
+    /// Queues an expected request and specifies its response handler
+    func expect<ResponseValue : Encodable>(path: String, method: HTTPMethod, handler: @escaping () -> ResponseValue) {
+        expectations.append(Expectation(path: path, method: method, handler: {
+            let responseValue = handler()
+            return ResponseValue.self == CodableNone.self ? nil : try! JSONEncoder().encode(responseValue)
+        }))
+    }
+
+    /// Queues an expected request
+    func expect(path: String, method: HTTPMethod) {
+        expect(path: path, method: method) { CodableNone() }
+    }
+
+    @discardableResult
+    func send<Request: WebDriverRequest>(_ request: Request) throws -> Request.Response {
+        XCTAssertNotEqual(expectations.count, 0)
+
+        let expectation = expectations.remove(at: 0)
+        XCTAssertEqual(request.pathComponents.joined(separator: "/"), expectation.path)
+        XCTAssertEqual(request.method, expectation.method)
+
+        let responseValue = expectation.handler()
+
+        var response = Request.Response()
+        if Request.ResponseValue.self == WebDriverNoResponseValue.self {
+            XCTAssertNil(responseValue)
+        }
+        else {
+            XCTAssertNotNil(responseValue)
+            response.value = try JSONDecoder().decode(Request.ResponseValue.self, from: responseValue!)
+        }
+        return response
+    }
+}


### PR DESCRIPTION
Allows testing library functionality without relying on `WinAppDriver.exe` and built-in Windows apps.