### PR TITLE
Christian/arc shexec

### DIFF
--- a/Sources/ProcessWrapper.swift
+++ b/Sources/ProcessWrapper.swift
@@ -1,0 +1,21 @@
+import Foundation
+import WinSDK
+
+// Enum to hold either a Process or a PID (processId) obtained from Windows
+// depending on how we launched an application
+enum ProcessWrapper {
+    case none
+    case swift (process: Process?)
+    case windows (processId: DWORD)
+
+    var processId: DWORD {
+        switch self {
+            case .swift(let process):
+                return DWORD(process?.processIdentifier ?? 0)
+            case .windows(let processId):
+                return processId
+            default:
+                return 0
+        }
+    }
+}

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -6,7 +6,7 @@ public class Session {
     let id: String
 
     // Process of the app being tested when launched directly (not through WinAppDriver)
-    var appProcess : Process?
+    var appProcess : ProcessWrapper?
 
     init(in webDriver: some WebDriver, id: String){
         self.webDriver = webDriver

--- a/Sources/WebDriverError.swift
+++ b/Sources/WebDriverError.swift
@@ -26,6 +26,7 @@ struct WebDriverError : Codable, Error {
         case invalidSelector = 32
         case sessionNotCreatedException = 33
         case moveTargetOutOfBounds = 34
+        case invalidArgument = 100          // returned by WinAppDriver when passing an incorrect window handle to attach to
     }
     
     var status: Status?

--- a/Tests/WebDriverTests/NotepadTests.swift
+++ b/Tests/WebDriverTests/NotepadTests.swift
@@ -6,7 +6,7 @@ class Notepad {
     let session: Session
     init(winAppDriver: WinAppDriver, appArguments: [String]?, appWorkingDir: String?) {
         let windowsDir = ProcessInfo.processInfo.environment["SystemRoot"]!
-        session = winAppDriver.newAttachedSession(app: "\(windowsDir)\\System32\\notepad.exe", 
+        session = winAppDriver.newSession(app: "\(windowsDir)\\System32\\notepad.exe", 
             appArguments: appArguments, appWorkingDir: appWorkingDir)
     }
 


### PR DESCRIPTION
To get around WIN-569 this change adds the ability to start an app with ShellExecuteEx. This should allow to work around this bug. 