### PR TITLE
Fix publics so that @testable is not required for webdriver-swift consumers

### DIFF
--- a/Sources/WinAppDriver.swift
+++ b/Sources/WinAppDriver.swift
@@ -13,7 +13,7 @@ public class WinAppDriver: WebDriver {
     }
     var runningProcess: RunningProcess? = nil
 
-    init() throws {
+    public init() throws {
         httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(Self.ip):\(Self.port)")!)
         
         // We start WinAppDriver only if its process is not already started


### PR DESCRIPTION
Added missing `public` to allow consumers to not have to specify `@testable` which does not work for release builds.