### PR TITLE
Default to building with swift.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ xcuserdata/
 DerivedData/
 .swiftpm/
 .netrc
-.vscode/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "swift",
+			"args": [
+				"build",
+				"--build-tests",
+				"-Xlinker",
+				"-debug:dwarf"
+			],
+			"cwd": ".",
+			"disableTaskQueue": true,
+			"problemMatcher": [
+				"$swiftc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "swift: Build All",
+			"detail": "swift build --build-tests -Xlinker -debug:dwarf"
+		}
+	]
+}


### PR DESCRIPTION
Motivated by the absence of https://github.com/microsoft/vscode-cmake-tools/issues/3257 and to minimize developer confusion.
The contents of the tasks.json file in this commit are what VSCode auto-populated, minus a `cwd` value that included my username.

Also drop the .gitignore'ing of the .vscode directory, since this is something we do want developers to share.

## Testing
`code .` in the webdriver-swift checkout directory and hitting `ctrl-shift-B` triggers the swift build without prompting about other build system.s