### PR TITLE
Jeff/fix session delete response

### DIFF
--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -37,7 +37,7 @@ public class Session {
     }
 
     struct DeleteSessionRequest: WebDriverRequest {
-        typealias ResponseValue = WebDriverResponseNoValue
+        typealias Response = WebDriverResponseNoValue
 
         let sessionId: String
         var pathComponents: [String] { ["session", sessionId] }


### PR DESCRIPTION
This fixes the decoding error.  We were trying to decode the response as a `WebDriverResponse<WebDriverResponseNoValue>`, when in reality, we just want `WebDriverResponseNoValue`.