### PR TITLE
Rename makePNGScreenshot to screenshot to follow the webdriver naming.

### DIFF
--- a/Sources/Session+Requests.swift
+++ b/Sources/Session+Requests.swift
@@ -26,9 +26,9 @@ extension Session {
 
     /// screenshot()
     /// Take a screenshot of the current page.
-    /// - Returns: The screenshot Data.
+    /// - Returns: The screenshot data as a PNG file.
     /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidscreenshot
-    public func makePNGScreenshot() throws -> Data {
+    public func screenshot() throws -> Data {
         let screenshotRequest = ScreenshotRequest(self)
 
         let base64: String = try webDriver.send(screenshotRequest).value

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -17,7 +17,7 @@ class APIToRequestMappingTests: XCTestCase {
         XCTAssertEqual(try session.title, "mySession.title")
 
         mockWebDriver.expect(path: "session/mySession/screenshot", method: .get) { WebDriverResponse(value: base64TestImage) }
-        let data: Data = try session.makePNGScreenshot()
+        let data: Data = try session.screenshot()
         XCTAssert(isPNG(data: data))
 
         mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Session.ElementRequest.self) {

--- a/Tests/WebDriverTests/SessionTests.swift
+++ b/Tests/WebDriverTests/SessionTests.swift
@@ -40,7 +40,7 @@ class SessionTests: XCTestCase {
     }
 
     public func testScreenshot() throws {
-        let data: Data = try Self.session.makePNGScreenshot()
+        let data: Data = try Self.session.screenshot()
         XCTAssert(isPNG(data: data))
     }
 


### PR DESCRIPTION
Mea culpa since I suggested this name in the first place. Updated the documentation comment instead.