### PR TITLE
Fix session test flakiness

### DIFF
--- a/Tests/WebDriverTests/SessionTests.swift
+++ b/Tests/WebDriverTests/SessionTests.swift
@@ -26,8 +26,6 @@ class SessionTests: XCTestCase {
         if let setupError = Self.setupError {
             throw setupError
         }
-
-        continueAfterFailure = false
     }
 
     override public class func tearDown() {


### PR DESCRIPTION
It would previously sporadically fail with:

```
Test Case 'SessionTests.testKeysAndAttributes' started at 2023-08-15 14:00:53.108
D:\a\webdriver-swift\webdriver-swift\Tests\WebDriverTests\SessionTests.swift:60: error: SessionTests.testKeysAndAttributes : XCTAssertEqual failed: ("true") is not equal to ("false") - Element still has keyboard focus
```

So I removed the expectation that submitting the search query changes the focus, since it was already under a sleep due to unreliability. Now it's based on a click. I also split the keys and attributes tests.