### PR TITLE
Remove dependency of requests on Session/Element for layering

### DIFF
--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -33,7 +33,7 @@ class APIToRequestMappingTests: XCTestCase {
         _ = try session.activeElement!
 
         mockWebDriver.expect(path: "session/mySession/moveto", method: .post, type: Session.MoveToRequest.self) {
-            XCTAssertEqual($0.elementId, "myElement")
+            XCTAssertEqual($0.element, "myElement")
             XCTAssertEqual($0.xOffset, 30)
             XCTAssertEqual($0.yOffset, 0)
             return WebDriverResponseNoValue()


### PR DESCRIPTION
There's a conceptual layering in the codebase where the Session and Element structs can be built on top of Request structs, but this is not apparent because Request structs refer to Session/Element types. This refactoring is a step towards making this layering explicit. A follow-up will be to pull the requests in separate files.

- Replace Request dependencies on Session/Element with strings
- Make Request struct properties `var` instead of `let` for more swiftiness
- Rename `***Request` variables to `request` since the type is apparent from the context
- Changed all `var body` properties to computed properties based on fields of the request