### PR TITLE
Refactor NewSessionRequest and Capabilities to separate WinAppDriver functionality

### DIFF
--- a/Sources/Capabilities.swift
+++ b/Sources/Capabilities.swift
@@ -1,0 +1,26 @@
+public class Capabilities: Codable {
+    // From https://www.w3.org/TR/webdriver1/#dfn-capability
+    public var platformName: String?
+    public var setWindowRect: Bool?
+    public var timeouts: Timeouts?
+
+    // From https://www.selenium.dev/documentation/legacy/json_wire_protocol/#capabilities-json-object
+    public var takesScreenshot: Bool?
+    public var nativeEvents: Bool?
+
+    // See https://www.w3.org/TR/webdriver1/#dfn-table-of-session-timeouts
+    public struct Timeouts: Codable {
+        public var script: Int?
+        public var pageLoad: Int?
+        public var implicit: Int?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case platformName
+        case setWindowRect
+        case timeouts
+
+        case takesScreenshot
+        case nativeEvents
+    }
+}

--- a/Sources/NewSessionRequest.swift
+++ b/Sources/NewSessionRequest.swift
@@ -1,0 +1,23 @@
+struct NewSessionRequest<Caps: Capabilities>: WebDriverRequest {
+    public var requiredCapabilities: Caps?
+    public var desiredCapabilities: Caps?
+
+    init(requiredCapabilities: Caps? = nil, desiredCapabilities: Caps? = nil) {
+        self.requiredCapabilities = requiredCapabilities
+        self.desiredCapabilities = desiredCapabilities
+    }
+
+    var pathComponents: [String] { ["session"] }
+    var method: HTTPMethod { .post }
+    var body: Body { .init(requiredCapabilities: requiredCapabilities, desiredCapabilities: desiredCapabilities) }
+
+    struct Body: Codable {
+        var requiredCapabilities: Caps?
+        var desiredCapabilities: Caps?
+    }
+
+    struct Response: Codable {
+        public var sessionId: String
+        public var value: Caps
+    }
+}

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -4,12 +4,14 @@ import Foundation
 public class Session {
     let webDriver: any WebDriver
     public let id: String
+    public let capabilities: Capabilities
 
     private var deleted: Bool = false
 
-    init(in webDriver: some WebDriver, id: String) {
+    init(in webDriver: some WebDriver, id: String, capabilities: Capabilities) {
         self.webDriver = webDriver
         self.id = id
+        self.capabilities = capabilities
     }
 
     /// retryTimeout

--- a/Sources/WebDriver+Requests.swift
+++ b/Sources/WebDriver+Requests.swift
@@ -18,6 +18,11 @@ struct WebDriverStatusRequest: WebDriverRequest {
 }
 
 public struct WebDriverStatus: Codable {
+    // From WebDriver spec
+    var ready: Bool?
+    var message: String?
+
+    // From Selenium's legacy json protocol
     var build: Build?
     var os: OS?
 

--- a/Sources/WinAppDriver+ExtensionCapabilities.swift
+++ b/Sources/WinAppDriver+ExtensionCapabilities.swift
@@ -1,0 +1,49 @@
+extension WinAppDriver {
+    // See https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md
+    public class ExtensionCapabilities: Capabilities {
+        public var app: String?
+        public var appArguments: String?
+        public var appTopLevelWindow: String?
+        public var appWorkingDir: String?
+        public var platformVersion: String?
+        public var waitForAppLaunch: Int?
+        public var experimentalWebDriver: Bool?
+
+        public override init() { super.init() }
+
+        // Swift can't synthesize init(from:) for subclasses of Codable classes
+        public required init(from decoder: Decoder) throws {
+            try super.init(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            app = try? container.decodeIfPresent(String.self, forKey: .app)
+            appArguments = try? container.decodeIfPresent(String.self, forKey: .appArguments)
+            appTopLevelWindow = try? container.decodeIfPresent(String.self, forKey: .appTopLevelWindow)
+            appWorkingDir = try? container.decodeIfPresent(String.self, forKey: .appWorkingDir)
+            platformVersion = try? container.decodeIfPresent(String.self, forKey: .platformVersion)
+            waitForAppLaunch = try? container.decodeIfPresent(Int.self, forKey: .waitForAppLaunch)
+            experimentalWebDriver = try? container.decodeIfPresent(Bool.self, forKey: .experimentalWebDriver)
+        }
+
+        public override func encode(to encoder: Encoder) throws {
+            try super.encode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(app, forKey: .app)
+            try container.encodeIfPresent(appArguments, forKey: .appArguments)
+            try container.encodeIfPresent(appTopLevelWindow, forKey: .appTopLevelWindow)
+            try container.encodeIfPresent(appWorkingDir, forKey: .appWorkingDir)
+            try container.encodeIfPresent(platformVersion, forKey: .platformVersion)
+            try container.encodeIfPresent(waitForAppLaunch, forKey: .waitForAppLaunch)
+            try container.encodeIfPresent(experimentalWebDriver, forKey: .experimentalWebDriver)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case app
+            case appArguments
+            case appTopLevelWindow
+            case appWorkingDir
+            case platformVersion
+            case waitForAppLaunch = "ms:waitForAppLaunch"
+            case experimentalWebDriver = "ms:experimental-webdriver"
+        }
+    }
+}

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -9,7 +9,7 @@ let base64TestImage: String =
 class APIToRequestMappingTests: XCTestCase {
     func testSessionAndElement() throws {
         let mockWebDriver = MockWebDriver()
-        let session = Session(in: mockWebDriver, id: "mySession")
+        let session = Session(in: mockWebDriver, id: "mySession", capabilities: Capabilities())
         XCTAssertEqual(session.id, "mySession")
 
         // Session requests unit-tests


### PR DESCRIPTION
- Introduce a base `Capabilities` class from which `WinAppDriver`'s own capabilities extend
- Refactor the `NewSessionRequest` to be be generic on the `Capabilities` struct
- Exposed the capabilities returned by the WebDriver endpoint on the session