### PR TITLE
Avoid screaming caps in element property name

### DIFF
--- a/Sources/Session+Requests.swift
+++ b/Sources/Session+Requests.swift
@@ -106,7 +106,7 @@ extension Session {
             let responseValue: ElementRequest.ResponseValue
             do {
                 responseValue = try webDriver.send(elementRequest).value
-                return Element(in: self, id: responseValue.ELEMENT)
+                return Element(in: self, id: responseValue.element)
             } catch let error as WebDriverError where error.status == .noSuchElement {
                 return nil
             }
@@ -141,7 +141,11 @@ extension Session {
         }
 
         struct ResponseValue: Codable {
-            var ELEMENT: String
+            var element: String
+
+            enum CodingKeys: String, CodingKey {
+                case element = "ELEMENT"
+            }
         }
     }
 
@@ -156,7 +160,7 @@ extension Session {
             } catch let error as WebDriverError where error.status == .noSuchElement {
                 return nil
             }
-            return Element(in: self, id: value.ELEMENT)
+            return Element(in: self, id: value.element)
         }
     }
 
@@ -172,7 +176,11 @@ extension Session {
         var body: Body = .init()
 
         struct ResponseValue: Codable {
-            var ELEMENT: String
+            var element: String
+
+            enum CodingKeys: String, CodingKey {
+                case element = "ELEMENT"
+            }
         }
     }
 

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -23,12 +23,12 @@ class APIToRequestMappingTests: XCTestCase {
         mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Session.ElementRequest.self) {
             XCTAssertEqual($0.using, "name")
             XCTAssertEqual($0.value, "myElement.name")
-            return WebDriverResponse(value: .init(ELEMENT: "myElement"))
+            return WebDriverResponse(value: .init(element: "myElement"))
         }
         let element = try session.findElement(byName: "myElement.name")!
 
         mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Session.ActiveElementRequest.self) {
-            WebDriverResponse(value: .init(ELEMENT: "myElement"))
+            WebDriverResponse(value: .init(element: "myElement"))
         }
         _ = try session.activeElement!
 


### PR DESCRIPTION
WebDriver might return an `ELEMENT` json property, but we don't have to use that name for the Swift property.