### PR TITLE
Ignore .build folder in SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+excluded:
+  - .build


### PR DESCRIPTION
SwiftLint is spammy enough as it is without complaining on foreign code!