### PR TITLE
Cleanup function doc comments

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1,7 +1,6 @@
 import struct Foundation.TimeInterval
 
-// Represents an element in the WinAppDriver API
-// (https://github.com/microsoft/WinAppDriver/blob/master/Docs/SupportedAPIs.md)
+// Represents an element in the WebDriver protocol.
 public struct Element {
     var webDriver: WebDriver { session.webDriver }
     public let session: Session
@@ -12,8 +11,41 @@ public struct Element {
         self.id = id
     }
 
-    /// click() - simulate clicking this Element
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidclick
+    /// The element's textual contents.
+    public var text: String {
+        get throws {
+            try webDriver.send(Requests.ElementText(
+                session: session.id, element: id)).value
+        }
+    }
+
+    /// The x and y location of the element relative to the screen top left corner.
+    public var location: (x: Int, y: Int) {
+        get throws {
+            let responseValue = try webDriver.send(Requests.ElementLocation(
+                session: session.id, element: id)).value
+            return (responseValue.x, responseValue.y)
+        }
+    }
+
+    /// Gets the width and height of this element in pixels.
+    public var size: (width: Int, height: Int) {
+        get throws {
+            let responseValue = try webDriver.send(Requests.ElementSize(
+                session: session.id, element: id)).value
+            return (responseValue.width, responseValue.height)
+        }
+    }
+
+    /// Gets a value indicating whether this element is currently displayed.
+    public var displayed: Bool {
+        get throws {
+            try webDriver.send(Requests.ElementDisplayed(
+                session: session.id, element: id)).value
+        }
+    }
+
+    /// Clicks this element.
     public func click(retryTimeout: TimeInterval? = nil) throws {
         let request = Requests.ElementClick(session: session.id, element: id)
         try retryUntil(retryTimeout ?? session.defaultRetryTimeout) {
@@ -26,7 +58,7 @@ public struct Element {
         }
     }
 
-    /// Simulates clicking this element via touch.
+    /// Clicks this element via touch.
     public func touchClick(kind: TouchClickKind = .single, retryTimeout: TimeInterval? = nil) throws {
         let request = Requests.SessionTouchClick(session: session.id, kind: kind, element: id)
         try retryUntil(retryTimeout ?? session.defaultRetryTimeout) {
@@ -39,118 +71,62 @@ public struct Element {
         }
     }
 
-    /// text - the element text
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidtext
-    public var text: String {
-        get throws {
-            try webDriver.send(Requests.ElementText(
-                session: session.id, element: id)).value
-        }
-    }
-
-    /// findElement(byName:)
     /// Search for an element by name, starting from this element.
-    /// - Parameter byName: name of the element to search for
-    ///  (https://learn.microsoft.com/en-us/windows/win32/winauto/inspect-objects)
+    /// - Parameter byName: name of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
-    /// - Returns: a new instance of Element wrapping the found element, nil if not found
-    /// - calls fatalError for any other error
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidelement
+    /// - Returns: The element that was found, if any.
     public func findElement(byName name: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
         try findElement(using: "name", value: name, retryTimeout: retryTimeout)
     }
 
-    /// findElement(byAccessibilityId:)
-    /// Search for an element in the accessibility tree, starting from this element
-    /// - Parameter byAccessiblityId: accessibiilty id of the element to search for
+    /// Search for an element in the accessibility tree, starting from this element.
+    /// - Parameter byAccessiblityId: accessibiilty id of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
-    /// - Returns: a new instance of Element wrapping the found element, nil if not found
-    /// - calls fatalError for any other error
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidelement
+    /// - Returns: The element that was found, if any.
     public func findElement(byAccessibilityId id: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
         try findElement(using: "accessibility id", value: id, retryTimeout: retryTimeout)
     }
 
-    /// findElement(byXPath:)
-    /// Search for an element by xpath, starting from this element
-    /// - Parameter byXPath: xpath of the element to search for
+    /// Search for an element by xpath, starting from this element.
+    /// - Parameter byXPath: xpath of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
-    /// - Returns: a new instance of Element wrapping the found element, nil if not found
-    /// - calls fatalError for any other error
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidelement
+    /// - Returns: a new instance of Element wrapping the found element, nil if not found.
     public func findElement(byXPath xpath: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
         try findElement(using: "xpath", value: xpath, retryTimeout: retryTimeout)
     }
 
-    /// findElement(byClassName:)
-    /// Search for an element by class name, starting from this element
-    /// - Parameter byClassName: class name of the element to search for
+    /// Search for an element by class name, starting from this element.
+    /// - Parameter byClassName: class name of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
-    /// - Returns: a new instance of Element wrapping the found element, nil if not found
-    /// - calls fatalError for any other error
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidelement
+    /// - Returns: The element that was found, if any.
     public func findElement(byClassName className: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
         try findElement(using: "class name", value: className, retryTimeout: retryTimeout)
     }
 
-    // Helper for findElement functions above
+    // Helper for findElement functions above.
     private func findElement(using: String, value: String, retryTimeout: TimeInterval?) throws -> Element? {
         try session.findElement(startingAt: self, using: using, value: value, retryTimeout: retryTimeout)
     }
 
-    /// getAttribute(name:)
-    /// Return a specific attribute of an element
-    /// - Parameter name: the attribute name as given by inspect.exe
-    /// - Returns: the attribute value string
-    /// - calls fatalError for any other error
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidattributename
+    /// Gets an attribute of this element.
+    /// - Parameter name: the attribute name.
+    /// - Returns: the attribute value string.
     public func getAttribute(name: String) throws -> String {
         try webDriver.send(Requests.ElementAttribute(
             session: session.id, element: id, attribute: name)).value
     }
 
-    /// location - return x, y location of the element relative to the screen top left corner
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidlocation
-    public var location: (x: Int, y: Int) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.ElementLocation(
-                session: session.id, element: id)).value
-            return (responseValue.x, responseValue.y)
-        }
-    }
-
-    /// size - return width, height of the element
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidsize
-    public var size: (width: Int, height: Int) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.ElementSize(
-                session: session.id, element: id)).value
-            return (responseValue.width, responseValue.height)
-        }
-    }
-
-    /// displayed - Determine if an element is currently displayed.
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementiddisplayed
-    public var displayed: Bool {
-        get throws {
-            try webDriver.send(Requests.ElementDisplayed(
-                session: session.id, element: id)).value
-        }
-    }
-
-    /// Send keys to an element
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidvalue
+    /// Send keys to this element.
     public func sendKeys(value: [String]) throws {
         try webDriver.send(Requests.ElementValue(
             session: session.id, element: id, value: value))
     }
 
-    /// Send keys to an element
-    /// This overload takes a single string for simplicity
+    /// Send keys to this element.
+    /// This overload takes a single string for simplicity.
     public func sendKeys(value: String) throws { try sendKeys(value: [value]) }
 
-    /// Clears the text of an editable element
-    /// https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidclear
+    /// Clears the text of an editable element.
     public func clear() throws {
         try webDriver.send(Requests.ElementClear(
             session: session.id, element: id))

--- a/Sources/Requests.swift
+++ b/Sources/Requests.swift
@@ -19,6 +19,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidattributename
     public struct ElementAttribute: Request {
         public var session: String
         public var element: String
@@ -30,6 +31,7 @@ public enum Requests {
         public typealias Response = ResponseWithValue<String>
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidclear
     public struct ElementClear: Request {
         public var session: String
         public var element: String
@@ -38,6 +40,7 @@ public enum Requests {
         public var method: HTTPMethod { .post }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidclick
     public struct ElementClick: Request {
         public var session: String
         public var element: String
@@ -46,6 +49,7 @@ public enum Requests {
         public var method: HTTPMethod { .post }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementiddisplayed
     public struct ElementDisplayed: Request {
         public var session: String
         public var element: String
@@ -60,6 +64,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidvalue
     public struct ElementValue: Request {
         public var session: String
         public var element: String
@@ -75,6 +80,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidlocation
     public struct ElementLocation: Request {
         public var session: String
         public var element: String
@@ -89,6 +95,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidsize
     public struct ElementSize: Request {
         public var session: String
         public var element: String
@@ -103,6 +110,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidtext
     public struct ElementText: Request {
         public var session: String
         public var element: String
@@ -137,6 +145,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementactive
     public struct SessionActiveElement: Request {
         public var session: String
 
@@ -146,6 +155,9 @@ public enum Requests {
         public typealias Response = ResponseWithValue<ElementResponseValue>
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidbuttondown
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidbuttonup
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidclick
     public struct SessionButton: Request {
         public var session: String
         public var action: Action
@@ -166,6 +178,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionid
     public struct SessionDelete: Request {
         public var session: String
 
@@ -173,6 +186,7 @@ public enum Requests {
         public var method: HTTPMethod { .delete }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessioniddoubleclick
     public struct SessionDoubleClick: Request {
         public var session: String
 
@@ -180,6 +194,8 @@ public enum Requests {
         public var method: HTTPMethod { .post }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelement
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidelement
     public struct SessionElement: Request {
         public var session: String
         public var element: String? = nil
@@ -205,6 +221,7 @@ public enum Requests {
         public typealias Response = ResponseWithValue<ElementResponseValue>
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidkeys
     public struct SessionKeys: Request {
         public var session: String
         public var value: [String]
@@ -218,6 +235,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidmoveto
     public struct SessionMoveTo: Request {
         public var session: String
         public var element: String?
@@ -241,6 +259,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidscreenshot
     public struct SessionScreenshot: Request {
         public var session: String
 
@@ -250,6 +269,7 @@ public enum Requests {
         public typealias Response = ResponseWithValue<String>
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtimeouts
     public struct SessionTimeouts: Request {
         public var session: String
         public var type: String
@@ -265,6 +285,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtitle
     public struct SessionTitle: Request {
         public var session: String
 
@@ -274,6 +295,9 @@ public enum Requests {
         public typealias Response = ResponseWithValue<String>
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchmove
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchdown
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchup
     public struct SessionTouchAt: Request {
         public var session: String
         public var action: Action
@@ -296,6 +320,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchclick
     public struct SessionTouchClick: Request {
         public var session: String
         public var kind: TouchClickKind
@@ -310,6 +335,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchscroll
     public struct SessionTouchScroll: Request {
         public var session: String
         public var element: String?
@@ -333,6 +359,7 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#status
     public struct Status: Request {
         public var pathComponents: [String] { ["status"] }
         public var method: HTTPMethod { .get }


### PR DESCRIPTION
- Move url protocol references to the request structs
- Remove redundant function names
- Standardize use of third person singular
- Standardize use of periods
- Remove stale fatal error notes