### PR TITLE
Ignore LNK4217 when linking tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,6 @@ let package = Package(
             name: "UnitTests",
             dependencies: ["WebDriver", "TestsCommon"],
             // Ignore "LNK4217: locally defined symbol imported" spew due to SPM library support limitations
-            linkerSettings: [ .unsafeFlags(["-Xlinker", "-ignore:4217"]) ])),
+            linkerSettings: [ .unsafeFlags(["-Xlinker", "-ignore:4217"]) ]),
     ]
 )


### PR DESCRIPTION
Fix tracked by https://github.com/thebrowsercompany/swift-build/issues/31