### PR TITLE
Use named factory methods for WinAppDriver and its Capabilities.

### DIFF
--- a/Sources/WinAppDriver/WinAppDriver+Capabilities.swift
+++ b/Sources/WinAppDriver/WinAppDriver+Capabilities.swift
@@ -1,3 +1,5 @@
+import struct Foundation.TimeInterval
+
 extension WinAppDriver {
     // See https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md
     public class Capabilities: BaseCapabilities {
@@ -11,17 +13,25 @@ extension WinAppDriver {
 
         public override init() { super.init() }
 
-        public convenience init(app: String, appArguments: [String] = [], appWorkingDir: String? = nil, waitForAppLaunch: Int? = nil) {
-            self.init()
-            self.app = app
-            self.appArguments = appArguments.isEmpty ? nil : buildCommandLineArgsString(args: appArguments)
-            self.appWorkingDir = appWorkingDir
-            self.waitForAppLaunch = waitForAppLaunch
+        public static func startApp(name: String, arguments: [String] = [], workingDir: String? = nil, waitTime: TimeInterval? = nil) -> Capabilities {
+            let caps = Capabilities()
+            caps.app = name
+            caps.appArguments = arguments.isEmpty ? nil : buildCommandLineArgsString(args: arguments)
+            caps.appWorkingDir = workingDir
+            if let waitTime { caps.waitForAppLaunch = Int(waitTime * 1000) }
+            return caps
         }
 
-        public convenience init(appTopLevelWindowHandle: UInt) {
-            self.init()
-            appTopLevelWindow = String(appTopLevelWindowHandle, radix: 16)
+        public static func attachToApp(topLevelWindowHandle: UInt) -> Capabilities {
+            let caps = Capabilities()
+            caps.appTopLevelWindow = String(topLevelWindowHandle, radix: 16)
+            return caps
+        }
+
+        public static func attachToDesktop() -> Capabilities {
+            let caps = Capabilities()
+            caps.app = "Root"
+            return caps
         }
 
         // Swift can't synthesize init(from:) for subclasses of Codable classes

--- a/Sources/WinAppDriver/WindowsSystemPaths.swift
+++ b/Sources/WinAppDriver/WindowsSystemPaths.swift
@@ -1,0 +1,17 @@
+import class Foundation.ProcessInfo
+
+enum WindowsSystemPaths {
+    static var systemDrive: String { ProcessInfo.processInfo.environment["SystemDrive"] ?? "C:" }
+
+    static var programFilesX86: String {
+        ProcessInfo.processInfo.environment["ProgramFiles(x86)"] ?? "\(systemDrive)\\Program Files (x86)"
+    }
+
+    static var windowsDir: String {
+        ProcessInfo.processInfo.environment["windir"]
+            ?? ProcessInfo.processInfo.environment["SystemRoot"]
+            ?? "\(systemDrive)\\Windows"
+    }
+
+    static var system32: String { "\(windowsDir)\\System32" }
+}

--- a/Tests/WebDriverTests/NotepadTests.swift
+++ b/Tests/WebDriverTests/NotepadTests.swift
@@ -6,12 +6,11 @@ class Notepad {
     let session: Session
     let editor: Element
 
-    init(winAppDriver: WinAppDriver, appArguments: [String] = [], appWorkingDir: String? = nil) throws {
-        let windowsDir = ProcessInfo.processInfo.environment["SystemRoot"]!
-        let capabilities = WinAppDriver.Capabilities(
-            app: "\(windowsDir)\\System32\\notepad.exe",
-            appArguments: appArguments,
-            appWorkingDir: appWorkingDir)
+    init(winAppDriver: WinAppDriver, arguments: [String] = [], workingDir: String? = nil) throws {
+        let capabilities = WinAppDriver.Capabilities.startApp(
+            name: "\(WindowsSystemPaths.system32)\\notepad.exe",
+            arguments: arguments,
+            workingDir: workingDir)
         session = try Session(webDriver: winAppDriver, desiredCapabilities: capabilities, requiredCapabilities: capabilities)
 
         // In Notepad Win11, findElement for name "Text Editor" or class "Edit" does not work
@@ -52,7 +51,7 @@ class NotepadTests: XCTestCase {
 
     override public class func setUp() {
         do {
-            winAppDriver = try WinAppDriver()
+            winAppDriver = try WinAppDriver.start()
         } catch {
             setupError = error
         }
@@ -74,7 +73,7 @@ class NotepadTests: XCTestCase {
     // TODO: implement a way to confirm that the dialog was dismissed and notepad exited,
     // e.g., by attempting to get the window handle from the session
     public func testDismissNewFileDialog() throws {
-        let notepad = try Notepad(winAppDriver: Self.winAppDriver, appArguments: [UUID().uuidString], appWorkingDir: NSTemporaryDirectory())
+        let notepad = try Notepad(winAppDriver: Self.winAppDriver, arguments: [UUID().uuidString], workingDir: NSTemporaryDirectory())
         try notepad.dismissNewFileDialog()
     }
 

--- a/Tests/WebDriverTests/SessionTests.swift
+++ b/Tests/WebDriverTests/SessionTests.swift
@@ -13,10 +13,9 @@ class SessionTests: XCTestCase {
     override public class func setUp() {
         do {
             // We don't store webDriver as session maintains a reference.
-            let winAppDriver = try WinAppDriver()
-            let windowsDir = ProcessInfo.processInfo.environment["SystemRoot"]!
-            let capabilities = WinAppDriver.Capabilities(
-                app: "\(windowsDir)\\System32\\msinfo32.exe")
+            let winAppDriver = try WinAppDriver.start()
+            let capabilities = WinAppDriver.Capabilities.startApp(
+                name: "\(WindowsSystemPaths.system32)\\msinfo32.exe")
             session = try Session(webDriver: winAppDriver, desiredCapabilities: capabilities, requiredCapabilities: capabilities)
         } catch {
             setupError = error

--- a/Tests/WebDriverTests/StatusTests.swift
+++ b/Tests/WebDriverTests/StatusTests.swift
@@ -7,7 +7,7 @@ class StatusTest: XCTestCase {
 
     override public class func setUp() {
         do {
-            winAppDriver = try WinAppDriver()
+            winAppDriver = try WinAppDriver.start()
         } catch {
             setupError = error
         }

--- a/Tests/WebDriverTests/TimeoutTests.swift
+++ b/Tests/WebDriverTests/TimeoutTests.swift
@@ -6,7 +6,7 @@ class TimeoutTests: XCTestCase {
     public var winAppDriver: WinAppDriver! { try? Self._winAppDriver.get() }
 
     public override class func setUp() {
-        _winAppDriver = Result { try WinAppDriver() }
+        _winAppDriver = Result { try WinAppDriver.start() }
     }
 
     public override class func tearDown() {
@@ -19,8 +19,8 @@ class TimeoutTests: XCTestCase {
 
     func startApp() throws -> Session {
         // Use a simple app in which we can expect queries to execute quickly
-        let windowsDir = ProcessInfo.processInfo.environment["SystemRoot"]!
-        let capabilities = WinAppDriver.Capabilities(app: "\(windowsDir)\\System32\\winver.exe")
+        let capabilities = WinAppDriver.Capabilities.startApp(
+            name: "\(WindowsSystemPaths.system32)\\winver.exe")
         return try Session(webDriver: winAppDriver, desiredCapabilities: capabilities)
     }
 


### PR DESCRIPTION
Overloading initializers was not as clear and required putting the verb in the label of the first argument, which would not have worked for `WinAppDriver.Capabilities.attachToDesktop` since it takes no arguments. I think it's useful to distinguish between different operations clearly.

Also factored the different places where we use `ProcessInfo` to figure out standard windows paths into a `WindowsSystemPaths` type. This could eventually use `SHGetKnownFolderPath` instead of environment variables.

Fixes #81