### PR TITLE
Remove the default retry timeout.

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -48,7 +48,7 @@ public struct Element {
     /// Clicks this element.
     public func click(retryTimeout: TimeInterval? = nil) throws {
         let request = Requests.ElementClick(session: session.id, element: id)
-        let result = try poll(timeout: retryTimeout ?? session.defaultRetryTimeout) {
+        let result = try poll(timeout: retryTimeout ?? session.defaultRetryTimeout ?? 0) {
             do {
                 // Immediately bubble most failures, only retry on element not interactable.
                 try webDriver.send(request)
@@ -64,7 +64,7 @@ public struct Element {
     /// Clicks this element via touch.
     public func touchClick(kind: TouchClickKind = .single, retryTimeout: TimeInterval? = nil) throws {
         let request = Requests.SessionTouchClick(session: session.id, kind: kind, element: id)
-        let result = try poll(timeout: retryTimeout ?? session.defaultRetryTimeout) {
+        let result = try poll(timeout: retryTimeout ?? session.defaultRetryTimeout ?? 0) {
             do {
                 // Immediately bubble most failures, only retry on element not interactable.
                 try webDriver.send(request)

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -23,8 +23,8 @@ public class Session {
     }
 
     /// A TimeInterval specifying max time to spend retrying operations.
-    public var defaultRetryTimeout: TimeInterval = 1.0 {
-        willSet { precondition(newValue >= 0) }
+    public var defaultRetryTimeout: TimeInterval? = 0 {
+        willSet { precondition((newValue ?? 0) >= 0) }
     }
 
     /// The title of this session such as the tab or window text.
@@ -143,7 +143,7 @@ public class Session {
 
         let request = Requests.SessionElement(session: id, element: element?.id, using: using, value: value)
 
-        let elementId = try poll(timeout: retryTimeout ?? defaultRetryTimeout) {
+        let elementId = try poll(timeout: retryTimeout ?? defaultRetryTimeout ?? 0) {
             let elementId: String?
             do {
                 // Allow errors to bubble up unless they are specifically saying that the element was not found.


### PR DESCRIPTION
`webdriver-swift` should not dictate what is the correct default retry timeout for every testing application. The burden of choosing that magic number should be higher level. This is similar to how the implicit wait timeout in webdriver defaults to zero.