### PR TITLE
Make findElements return a nonoptional array

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -126,7 +126,7 @@ public struct Element {
     /// - Parameter byId: id of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element]? {
+    public func findElements(byId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
         try findElements(using: "id", value: id, retryTimeout: retryTimeout)
     }
 
@@ -134,7 +134,7 @@ public struct Element {
     /// - Parameter byName: name of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byName name: String, retryTimeout: TimeInterval? = nil) throws -> [Element]? {
+    public func findElements(byName name: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
         try findElements(using: "name", value: name, retryTimeout: retryTimeout)
     }
 
@@ -142,7 +142,7 @@ public struct Element {
     /// - Parameter byAccessibilityId: accessibiilty id of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byAccessibilityId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element]? {
+    public func findElements(byAccessibilityId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
         try findElements(using: "accessibility id", value: id, retryTimeout: retryTimeout)
     }
 
@@ -150,7 +150,7 @@ public struct Element {
     /// - Parameter byXPath: xpath of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byXPath xpath: String, retryTimeout: TimeInterval? = nil) throws -> [Element]? {
+    public func findElements(byXPath xpath: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
         try findElements(using: "xpath", value: xpath, retryTimeout: retryTimeout)
     }
 
@@ -158,12 +158,12 @@ public struct Element {
     /// - Parameter byClassName: class name of the element to search for.
     /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byClassName className: String, retryTimeout: TimeInterval? = nil) throws -> [Element]? {
+    public func findElements(byClassName className: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
         try findElements(using: "class name", value: className, retryTimeout: retryTimeout)
     }
 
     // Helper for findElements functions above.
-    private func findElements(using: String, value: String, retryTimeout: TimeInterval?) throws -> [Element]? {
+    private func findElements(using: String, value: String, retryTimeout: TimeInterval?) throws -> [Element] {
         try session.findElements(startingAt: self, using: using, value: value, retryTimeout: retryTimeout)
     }
 


### PR DESCRIPTION
Removes the nullability of the returned array, since it is not clear how `nil` is semantically distinct from `[]`, and this makes the API easier to consume (no nil handling). This matches the webdriver spec.

Also fixes a build break due to a merge conflict with `Element(in:id:)` being renamed to `Element(session:id:)`

~~Rationale: With `findElement`, we can know that an item was not found and retry until it is found. With `findElements` however, we can detect that no element was found and retry until one element is found, but we can't detect that only one element was found when there should have been two and then retry until we get two elements. For consistency, it's better to never poll and only return the first result.~~