### PR TITLE
Implement `Element.enabled`.

### DIFF
--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -27,7 +27,7 @@ Contributions to expand support to unimplemented functionality are always welcom
 | GET    | `/session/:sessionId/element/:id/displayed`         | Supported    | `Element.displayed` |
 | GET    | `/session/:sessionId/element/:id/element`           | Supported    | `Element.findElement()`|
 | GET    | `/session/:sessionId/element/:id/elements`          | Supported    | `Element.findElements()`|
-| GET    | `/session/:sessionId/element/:id/enabled`           | Supported    | Not implemented     |
+| GET    | `/session/:sessionId/element/:id/enabled`           | Supported    | `Element.enabled`   |
 | GET    | `/session/:sessionId/element/:id/equals`            | Supported    | Not implemented     |
 | GET    | `/session/:sessionId/element/:id/location`          | Supported    | `Element.location`  |
 | GET    | `/session/:sessionId/element/:id/location_in_view`  | Supported    | Not implemented     |

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -45,6 +45,14 @@ public struct Element {
         }
     }
 
+    /// Gets a value indicating whether this element is currently enabled.
+    public var enabled: Bool {
+        get throws {
+            try webDriver.send(Requests.ElementEnabled(
+                session: session.id, element: id)).value
+        }
+    }
+
     /// Clicks this element.
     public func click(retryTimeout: TimeInterval? = nil) throws {
         let request = Requests.ElementClick(session: session.id, element: id)

--- a/Sources/Requests.swift
+++ b/Sources/Requests.swift
@@ -76,6 +76,21 @@ public enum Requests {
         }
     }
 
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidenabled
+    public struct ElementEnabled: Request {
+        public var session: String
+        public var element: String
+
+        public var pathComponents: [String] { ["session", session, "element", element, "enabled"] }
+        public var method: HTTPMethod { .get }
+
+        // Override the whole Response struct instead of just ResponseValue
+        // because the value is a Bool, which does not conform to Codable.
+        public struct Response: Codable {
+            public var value: Bool
+        }
+    }
+
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidvalue
     public struct ElementValue: Request {
         public var session: String

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -159,4 +159,14 @@ class APIToRequestMappingTests: XCTestCase {
         }
         XCTAssert(try element.size == (width: 100, height: 200))
     }
+
+    func testElementEnabled() throws {
+        let mockWebDriver = MockWebDriver()
+        let session = Session(webDriver: mockWebDriver, existingId: "mySession")
+        let element = Element(session: session, id: "myElement")
+        mockWebDriver.expect(path: "session/mySession/element/myElement/enabled", method: .get) {
+            ResponseWithValue(true)
+        }
+        XCTAssert(try element.enabled == true)
+    }
 }

--- a/Tests/WinAppDriverTests/RequestsTests.swift
+++ b/Tests/WinAppDriverTests/RequestsTests.swift
@@ -50,6 +50,10 @@ class RequestsTests: XCTestCase {
         try XCTAssertEqual(app.findWhatEditBox.getAttribute(name: WinAppDriver.Attributes.className), "Edit")
     }
 
+    func testEnabled() throws {
+        try XCTAssert(app.findWhatEditBox.enabled)
+    }
+
     func testElementClickGivesKeyboardFocus() throws {
         try app.systemSummaryTree.click()
         try XCTAssert(!Self.hasKeyboardFocus(app.findWhatEditBox))


### PR DESCRIPTION
Just picking off low-hanging fruit from the list of unimplemented commands.