### PR TITLE
Fix missing import.

### DIFF
--- a/Sources/WinAppDriver/ErrorResponse+WinAppDriver.swift
+++ b/Sources/WinAppDriver/ErrorResponse+WinAppDriver.swift
@@ -1,3 +1,5 @@
+import WebDriver
+
 extension ErrorResponse.Status {
     // WinAppDriver returns when passing an incorrect window handle to attach to.
     static let winAppDriver_invalidArgument = Self(rawValue: 100)


### PR DESCRIPTION
The WebDriver / WinAppDriver split put a WebDriver class extension in WinAppDriver.  Which I guess is fine if you build with SPM, but it is not fine if you build with CMake.  

This is needed to build Arc test targets with CMake.