### PR TITLE
build: prevent building on non-Windows targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,10 @@
 
 import PackageDescription
 
+#if !os(Windows)
+fatalError("swift-webdriver does not support this OS")
+#endif
+
 let package = Package(
     name: "swift-webdriver",
     products: [


### PR DESCRIPTION
We currently rely on Windows specific behaviour and while in theory it is possible to port this to Linux, it is unlikely to be ported to Apple platforms. This simply properly indicates the error.