### PR TITLE
Make Session.windowHandle(s) into properties

### DIFF
--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -69,5 +69,5 @@ Contributions to expand support to unimplemented functionality are always welcom
 | POST   | `/session/:sessionId/window/:windowHandle/position` | Supported    | Not implemented     |
 | GET    | `/session/:sessionId/window/:windowHandle/position` | Supported    | Not implemented     |
 | POST   | `/session/:sessionId/window/:windowHandle/maximize` | Supported    | Not implemented     |
-| GET    | `/session/:sessionId/window_handle`                 | Supported    | `Session.windowHandle()`|
-| GET    | `/session/:sessionId/window_handles`                | Supported    | `Session.windowHandles()`|
+| GET    | `/session/:sessionId/window_handle`                 | Supported    | `Session.windowHandle`|
+| GET    | `/session/:sessionId/window_handles`                | Supported    | `Session.windowHandles`|

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -328,15 +328,19 @@ public class Session {
     }
  
     /// - Returns: Current window handle
-    public func windowHandle() throws -> String {
-        let response = try webDriver.send(Requests.SessionWindowHandle(session: id))
-        return response.value
+    public var windowHandle: String {
+        get throws {
+            let response = try webDriver.send(Requests.SessionWindowHandle(session: id))
+            return response.value
+        }
     }
 
     /// - Returns: Array of window handles
-    public func windowHandles() throws ->  [String] {
-        let response = try webDriver.send(Requests.SessionWindowHandles(session: id))
-        return response.value
+    public func windowHandles: [String] {
+        get throws {
+            let response = try webDriver.send(Requests.SessionWindowHandles(session: id))
+            return response.value
+        }
     }
 
     /// Deletes the current session.

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -336,7 +336,7 @@ public class Session {
     }
 
     /// - Returns: Array of window handles
-    public func windowHandles: [String] {
+    public var windowHandles: [String] {
         get throws {
             let response = try webDriver.send(Requests.SessionWindowHandles(session: id))
             return response.value

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -221,7 +221,7 @@ class APIToRequestMappingTests: XCTestCase {
         mockWebDriver.expect(path: "session/mySession/window_handle", method: .get, type: Requests.SessionWindowHandle.self) {
             ResponseWithValue(.init("myWindow"))
         }
-        XCTAssert(try session.windowHandle() == "myWindow")
+        XCTAssert(try session.windowHandle == "myWindow")
     }
 
     func testWindowHandles() throws {
@@ -231,7 +231,7 @@ class APIToRequestMappingTests: XCTestCase {
         mockWebDriver.expect(path: "session/mySession/window_handles", method: .get, type: Requests.SessionWindowHandles.self) {
             ResponseWithValue(.init(["myWindow", "myWindow"]))
         }
-        XCTAssert(try session.windowHandles() == ["myWindow", "myWindow"])
+        XCTAssert(try session.windowHandles == ["myWindow", "myWindow"])
     }
 
     func testSessionSource() throws {


### PR DESCRIPTION
Since they don't take arguments, they are better represented as properties.