### PR TITLE
Fix Session.source to respect standard

### DIFF
--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -548,12 +548,7 @@ public enum Requests {
         public var pathComponents: [String] { ["session", session, "source"] }
         public var method: HTTPMethod {.get}
 
-        public typealias Response = ResponseWithValue<ResponseValue>
-
-        public struct ResponseValue: Codable {
-            public var source: String
-        }
-
+        public typealias Response = ResponseWithValue<String>
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#status

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -321,10 +321,11 @@ public class Session {
         try webDriver.send(Requests.SessionWindowSize.Post(session: id, windowHandle: handle, width: width, height: height))
     }
 
-    /// - Returns: The current page source.
-    public func source() throws -> String {
-        let response = try webDriver.send(Requests.SessionSource(session: id))
-        return response.value.source
+    /// Get the current page source
+    public var source: String {
+        get throws {
+            try webDriver.send(Requests.SessionSource(session: id)).value
+        }
     }
  
     /// - Returns: Current window handle

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -239,8 +239,8 @@ class APIToRequestMappingTests: XCTestCase {
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
 
         mockWebDriver.expect(path: "session/mySession/source", method: .get, type: Requests.SessionSource.self) {
-            ResponseWithValue(.init(source: "currentSource"))
+            ResponseWithValue("currentSource")
         }
-        XCTAssert(try session.source() == "currentSource")
+        XCTAssert(try session.source == "currentSource")
     }
 }


### PR DESCRIPTION
It should return a string as the value directly rather than an object with a "source" key and the source as the value.

Also changes the parameterless getter to a property.