### PR TITLE
Ignore CMakeLists.txt in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     targets: [
         .target(
             name: "WebDriver",
-            path: "Sources/WebDriver"),
+            path: "Sources/WebDriver",
+            exclude: ["CMakeLists.txt"]),
         .target(
             name: "TestsCommon",
             path: "Tests/Common"),
@@ -30,7 +31,8 @@ package.targets += [
     .target(
         name: "WinAppDriver",
         dependencies: ["WebDriver"],
-        path: "Sources/WinAppDriver"),
+        path: "Sources/WinAppDriver",
+        exclude: ["CMakeLists.txt"]),
     .testTarget(
         name: "WinAppDriverTests",
         dependencies: ["TestsCommon", "WebDriver", "WinAppDriver"],
@@ -38,4 +40,3 @@ package.targets += [
         linkerSettings: [ .unsafeFlags(["-Xlinker", "-ignore:4217"]) ]),
 ]
 #endif
-


### PR DESCRIPTION
Prevents these warnings:

```
warning: 'swift-webdriver': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    <snip>\swift-webdriver\Sources\WinAppDriver\CMakeLists.txt
warning: 'swift-webdriver': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    <snip>\swift-webdriver\Sources\WebDriver\CMakeLists.txt
```