### PR TITLE
Store element's found method

### DIFF
--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -5,10 +5,14 @@ public struct Element {
     var webDriver: WebDriver { session.webDriver }
     public let session: Session
     public let id: String
+    public let foundUsing: String?
+    public let foundUsingValue: String?
 
-    public init(session: Session, id: String) {
+    public init(session: Session, id: String, foundUsing: String? = nil, foundUsingValue: String? = nil) {
         self.session = session
         self.id = id
+        self.foundUsing = foundUsing
+        self.foundUsingValue = foundUsingValue
     }
 
     /// The element's textual contents.

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -379,7 +379,8 @@ public class Session {
     }
 
     deinit {
-        do { try delete() } catch let error as ErrorResponse {
+        do { try delete() }
+        catch let error as ErrorResponse {
             assertionFailure("Error in Session.delete: \(error)")
         } catch {
             assertionFailure("Unexpected error in Session.delete: \(error)")

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -66,7 +66,7 @@ public class Session {
             }
         }
     }
-    
+
     public var location: Location {
         get throws {
             let response = try webDriver.send(Requests.SessionLocation.Get(session: id))
@@ -175,7 +175,7 @@ public class Session {
             return PollResult(value: elementId, success: elementId != nil)
         }.value
 
-        return elementId.map { Element(session: self, id: $0) }
+        return elementId.map { Element(session: self, id: $0, foundUsing: using, foundUsingValue: value) }
     }
 
     /// Finds elements by id, starting from the root.
@@ -225,7 +225,7 @@ public class Session {
         return try poll(timeout: retryTimeout ?? defaultRetryTimeout) {
             do {
                 // Allow errors to bubble up unless they are specifically saying that the element was not found.
-                return PollResult.success(try webDriver.send(request).value.map { Element(session: self, id: $0.element) })
+                return PollResult.success(try webDriver.send(request).value.map { Element(session: self, id: $0.element, foundUsing: using, foundUsingValue: value) })
             } catch let error as ErrorResponse where error.status == .noSuchElement {
                 // Follow the WebDriver spec and keep polling if no elements are found
                 return PollResult.failure([])
@@ -344,7 +344,7 @@ public class Session {
             try webDriver.send(Requests.SessionSource(session: id)).value
         }
     }
- 
+
     /// - Returns: Current window handle
     public var windowHandle: String {
         get throws {
@@ -358,8 +358,8 @@ public class Session {
         try webDriver.send(Requests.SessionLocation.Post(session: id, location: location))
     }
 
-    public func setLocation(latitude: Double, longitude: Double, altitude: Double) throws { 
-        try setLocation(Location(latitude: latitude, longitude: longitude, altitude: altitude)) 
+    public func setLocation(latitude: Double, longitude: Double, altitude: Double) throws {
+        try setLocation(Location(latitude: latitude, longitude: longitude, altitude: altitude))
     }
 
     /// - Returns: Array of window handles
@@ -379,8 +379,7 @@ public class Session {
     }
 
     deinit {
-        do { try delete() }
-        catch let error as ErrorResponse {
+        do { try delete() } catch let error as ErrorResponse {
             assertionFailure("Error in Session.delete: \(error)")
         } catch {
             assertionFailure("Unexpected error in Session.delete: \(error)")

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -51,7 +51,36 @@ class APIToRequestMappingTests: XCTestCase {
             XCTAssertEqual($0.value, "myElement.name")
             return ResponseWithValue(.init(element: "myElement"))
         }
-        XCTAssertNotNil(try session.findElement(byName: "myElement.name"))
+        let element = try session.findElement(byName: "myElement.name")
+        XCTAssertNotNil(element)
+        if let element {
+            XCTAssertEqual(element.foundUsing, "name")
+            XCTAssertEqual(element.foundUsingValue, "myElement.name")
+        }
+
+        mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Requests.SessionElement.self) {
+            XCTAssertEqual($0.using, "accessibility id")
+            XCTAssertEqual($0.value, "myElement2.accessibilityId")
+            return ResponseWithValue(.init(element: "myElement2"))
+        }
+        let element2 = try session.findElement(byAccessibilityId: "myElement2.accessibilityId")
+        XCTAssertNotNil(element2)
+        if let element2 {
+            XCTAssertEqual(element2.foundUsing, "accessibility id")
+            XCTAssertEqual(element2.foundUsingValue, "myElement2.accessibilityId")
+        }
+
+        mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Requests.SessionElement.self) {
+            XCTAssertEqual($0.using, "id")
+            XCTAssertEqual($0.value, "myElement3.Id")
+            return ResponseWithValue(.init(element: "myElement3"))
+        }
+        let element3 = try session.findElement(byId: "myElement3.Id")
+        XCTAssertNotNil(element3)
+        if let element3 {
+            XCTAssertEqual(element3.foundUsing, "id")
+            XCTAssertEqual(element3.foundUsingValue, "myElement3.Id")
+        }
 
         mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Requests.SessionActiveElement.self) {
             ResponseWithValue(.init(element: "myElement"))
@@ -97,7 +126,7 @@ class APIToRequestMappingTests: XCTestCase {
         }
         try session.buttonUp(button: .right)
     }
- 
+
     func testSessionOrientation() throws {
         let mockWebDriver: MockWebDriver = MockWebDriver()
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
@@ -250,10 +279,10 @@ class APIToRequestMappingTests: XCTestCase {
         let mockWebDriver: MockWebDriver = MockWebDriver()
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let location = Location(latitude: 5, longitude: 20, altitude: 2003)
-        
+
         mockWebDriver.expect(path: "session/mySession/location", method: .post)
         try session.setLocation(location)
-        
+
         mockWebDriver.expect(path: "session/mySession/location", method: .get, type: Requests.SessionLocation.Get.self) {
             ResponseWithValue(.init(latitude: 5, longitude: 20, altitude: 2003))
         }
@@ -281,13 +310,12 @@ class APIToRequestMappingTests: XCTestCase {
 
         let mockWebDriver: MockWebDriver = MockWebDriver()
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        
+
         mockWebDriver.expect(path: "session/mySession/window_handles", method: .get, type: Requests.SessionWindowHandles.self) {
             ResponseWithValue(.init(["myWindow", "myWindow"]))
         }
         XCTAssert(try session.windowHandles == ["myWindow", "myWindow"])
     }
-
 
     func testElementDoubleClick() throws {
         let mockWebDriver: MockWebDriver = MockWebDriver()


### PR DESCRIPTION
Store element's found method values, so it can be used to check if the element still exists. This allows a method like element.waitForNonExistence() to be implemented, to handle cases where the id may be reused by the Accessibility provider after an element is deleted.