### PR TITLE
Leverage WebDriver built-in implicit wait

### DIFF
--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -72,7 +72,7 @@ public struct Element {
     }
 
     /// - Parameters:
-    ///   - retryTimeout: Optional value to override defaultRetryTimeout.
+    ///   - retryTimeout: The amount of time to retry the operation. Overrides the implicit interaction retry timeout.
     ///   - element: Element id to click
     ///   - xOffset: The x offset in pixels to flick by.
     ///   - yOffset: The y offset in pixels to flick by.
@@ -84,92 +84,92 @@ public struct Element {
 
     /// Finds an element by id, starting from this element.
     /// - Parameter byId: id of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    public func findElement(byId id: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
-        try findElement(using: "id", value: id, retryTimeout: retryTimeout)
+    public func findElement(byId id: String, waitTimeout: TimeInterval? = nil) throws -> Element? {
+        try findElement(using: "id", value: id, waitTimeout: waitTimeout)
     }
 
     /// Search for an element by name, starting from this element.
     /// - Parameter byName: name of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    public func findElement(byName name: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
-        try findElement(using: "name", value: name, retryTimeout: retryTimeout)
+    public func findElement(byName name: String, waitTimeout: TimeInterval? = nil) throws -> Element? {
+        try findElement(using: "name", value: name, waitTimeout: waitTimeout)
     }
 
     /// Search for an element in the accessibility tree, starting from this element.
     /// - Parameter byAccessibilityId: accessibiilty id of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    public func findElement(byAccessibilityId id: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
-        try findElement(using: "accessibility id", value: id, retryTimeout: retryTimeout)
+    public func findElement(byAccessibilityId id: String, waitTimeout: TimeInterval? = nil) throws -> Element? {
+        try findElement(using: "accessibility id", value: id, waitTimeout: waitTimeout)
     }
 
     /// Search for an element by xpath, starting from this element.
     /// - Parameter byXPath: xpath of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: a new instance of Element wrapping the found element, nil if not found.
-    public func findElement(byXPath xpath: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
-        try findElement(using: "xpath", value: xpath, retryTimeout: retryTimeout)
+    public func findElement(byXPath xpath: String, waitTimeout: TimeInterval? = nil) throws -> Element? {
+        try findElement(using: "xpath", value: xpath, waitTimeout: waitTimeout)
     }
 
     /// Search for an element by class name, starting from this element.
     /// - Parameter byClassName: class name of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    public func findElement(byClassName className: String, retryTimeout: TimeInterval? = nil) throws -> Element? {
-        try findElement(using: "class name", value: className, retryTimeout: retryTimeout)
+    public func findElement(byClassName className: String, waitTimeout: TimeInterval? = nil) throws -> Element? {
+        try findElement(using: "class name", value: className, waitTimeout: waitTimeout)
     }
 
     // Helper for findElement functions above.
-    private func findElement(using: String, value: String, retryTimeout: TimeInterval?) throws -> Element? {
-        try session.findElement(startingAt: self, using: using, value: value, retryTimeout: retryTimeout)
+    private func findElement(using: String, value: String, waitTimeout: TimeInterval?) throws -> Element? {
+        try session.findElement(startingAt: self, using: using, value: value, waitTimeout: waitTimeout)
     }
 
     /// Search for elements by id, starting from this element.
     /// - Parameter byId: id of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
-        try findElements(using: "id", value: id, retryTimeout: retryTimeout)
+    public func findElements(byId id: String, waitTimeout: TimeInterval? = nil) throws -> [Element] {
+        try findElements(using: "id", value: id, waitTimeout: waitTimeout)
     }
 
     /// Search for elements by name, starting from this element.
     /// - Parameter byName: name of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byName name: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
-        try findElements(using: "name", value: name, retryTimeout: retryTimeout)
+    public func findElements(byName name: String, waitTimeout: TimeInterval? = nil) throws -> [Element] {
+        try findElements(using: "name", value: name, waitTimeout: waitTimeout)
     }
 
     /// Search for elements in the accessibility tree, starting from this element.
     /// - Parameter byAccessibilityId: accessibiilty id of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byAccessibilityId id: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
-        try findElements(using: "accessibility id", value: id, retryTimeout: retryTimeout)
+    public func findElements(byAccessibilityId id: String, waitTimeout: TimeInterval? = nil) throws -> [Element] {
+        try findElements(using: "accessibility id", value: id, waitTimeout: waitTimeout)
     }
 
     /// Search for elements by xpath, starting from this element.
     /// - Parameter byXPath: xpath of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byXPath xpath: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
-        try findElements(using: "xpath", value: xpath, retryTimeout: retryTimeout)
+    public func findElements(byXPath xpath: String, waitTimeout: TimeInterval? = nil) throws -> [Element] {
+        try findElements(using: "xpath", value: xpath, waitTimeout: waitTimeout)
     }
 
     /// Search for elements by class name, starting from this element.
     /// - Parameter byClassName: class name of the element to search for.
-    /// - Parameter retryTimeout: Optional value to override defaultRetryTimeout.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, if any.
-    public func findElements(byClassName className: String, retryTimeout: TimeInterval? = nil) throws -> [Element] {
-        try findElements(using: "class name", value: className, retryTimeout: retryTimeout)
+    public func findElements(byClassName className: String, waitTimeout: TimeInterval? = nil) throws -> [Element] {
+        try findElements(using: "class name", value: className, waitTimeout: waitTimeout)
     }
 
     // Helper for findElements functions above.
-    private func findElements(using: String, value: String, retryTimeout: TimeInterval?) throws -> [Element] {
-        try session.findElements(startingAt: self, using: using, value: value, retryTimeout: retryTimeout)
+    private func findElements(using: String, value: String, waitTimeout: TimeInterval?) throws -> [Element] {
+        try session.findElements(startingAt: self, using: using, value: value, waitTimeout: waitTimeout)
     }
 
     /// Gets an attribute of this element.

--- a/Sources/WebDriver/HTTPWebDriver.swift
+++ b/Sources/WebDriver/HTTPWebDriver.swift
@@ -6,7 +6,7 @@ import FoundationNetworking
 public struct HTTPWebDriver: WebDriver {
     let rootURL: URL
 
-    public static let defaultTimeout: TimeInterval = 5 // seconds
+    public static let defaultRequestTimeout: TimeInterval = 5 // seconds
 
     public init(endpoint: URL) {
         rootURL = endpoint
@@ -36,7 +36,7 @@ public struct HTTPWebDriver: WebDriver {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = request.method.rawValue
         // TODO(#40): Setting timeoutInterval causes a crash when sending the request on the CI machines.
-        // urlRequest.timeoutInterval = Self.defaultTimeout
+        // urlRequest.timeoutInterval = Self.defaultRequestTimeout
 
         // Add the body if the Request type defines one
         if Req.Body.self != CodableNone.self {

--- a/Tests/WinAppDriverTests/TimeoutTests.swift
+++ b/Tests/WinAppDriverTests/TimeoutTests.swift
@@ -37,16 +37,16 @@ class TimeoutTests: XCTestCase {
         let session = try startApp()
 
         // Test library timeout implementation
-        session.defaultRetryTimeout = 1
+        session.implicitWaitTimeout = 1
         XCTAssert(try Self.time({ _ = try session.findElement(byAccessibilityId: "IdThatDoesNotExist") }) > 0.5)
 
-        session.defaultRetryTimeout = 0
+        session.implicitWaitTimeout = 0
         XCTAssert(try Self.time({ _ = try session.findElement(byAccessibilityId: "IdThatDoesNotExist") }) < 0.5)
     }
 
     public func testWebDriverImplicitWait() throws {
         let session = try startApp()
-        session.defaultRetryTimeout = 0
+        session.implicitWaitTimeout = 0
 
         try session.setTimeout(type: TimeoutType.implicitWait, duration: 1)
         XCTAssert(try Self.time({ _ = try session.findElement(byAccessibilityId: "IdThatDoesNotExist") }) > 0.5)


### PR DESCRIPTION
We've been emulating implicit wait functionality by repeated requests when webdriver offers it as a built-in mechanism. Using the built-in mechanism when available has the advantage of making logs less verbose. This change preserves the repeated request emulation mechanism as a fallback.

This change aligns better with web driver concepts. We use "implicit wait timeout" instead of "default retry timeout", and make it only apply to `findElement`, introducing a separate "implicit interaction retry timeout" for interactions (which is not a webdriver protocol built-in functionality). The implicit wait timeout now defaults to 0 seconds, as per spec.

Individual operations still offer to specify a wait timeout, and this is implemented by temporarily changing the implicit wait timeout, since that is the only mechanism offered by webdriver.