### PR TITLE
Add Session/Element.requireElement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,10 +11,10 @@ A Swift library for UI automation of apps and browsers via communication with [W
 A `swift-webdriver` "Hello world" using `WinAppDriver` might look like this:
 
 ```swift
-let session = Session(
+let session = try Session(
     webDriver: WinAppDriver.start(), // Requires WinAppDriver to be installed on the machine
     desiredCapabilities: WinAppDriver.Capabilities.startApp(name: "notepad.exe"))
-session.findElement(locator: .name("close"))?.click()
+try session.requireElement(locator: .name("close")).click()
 ```
 
 To use `swift-webdriver` in your project, add a reference to it in your `Package.swift` file as follows:

--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(WebDriver
   Capabilities.swift
   Element.swift
   ElementLocator.swift
+  ElementNotFoundError.swift
   ErrorResponse.swift
   HTTPWebDriver.swift
   Keys.swift

--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -98,6 +98,16 @@ public struct Element {
         try session.findElements(startingAt: self, locator: locator, waitTimeout: waitTimeout)
     }
 
+    /// Finds an element using a given locator, starting from this element, and throwing upon failure.
+    /// - Parameter locator: The locator strategy to use.
+    /// - Parameter description: A human-readable description of the element, included in thrown errors.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
+    /// - Returns: The element that was found.
+    @discardableResult // for use as an assertion
+    public func requireElement(locator: ElementLocator, description: String? = nil, waitTimeout: TimeInterval? = nil) throws -> Element {
+        try session.requireElement(startingAt: self, locator: locator, description: description, waitTimeout: waitTimeout)
+    }
+
     /// Gets an attribute of this element.
     /// - Parameter name: the attribute name.
     /// - Returns: the attribute value string.

--- a/Sources/WebDriver/ElementNotFoundError.swift
+++ b/Sources/WebDriver/ElementNotFoundError.swift
@@ -1,0 +1,19 @@
+public struct ElementNotFoundError: Error {
+    /// The locator that was used to search for the element.
+    public var locator: ElementLocator
+
+    /// A human-readable description of the element.
+    public var description: String?
+
+    /// The error that caused the element to not be found.
+    public var sourceError: Error
+
+    public init(locator: ElementLocator, description: String? = nil, sourceError: Error) {
+        self.locator = locator
+        self.description = description
+        self.sourceError = sourceError
+    }
+
+    /// The error response returned by the WebDriver server, if this was the source of the failure.
+    public var errorResponse: ErrorResponse? { sourceError as? ErrorResponse }
+}

--- a/Sources/WebDriver/ErrorResponse.swift
+++ b/Sources/WebDriver/ErrorResponse.swift
@@ -38,7 +38,7 @@ public struct ErrorResponse: Codable, Error {
     }
 
     public struct Value: Codable {
-        public var error: String
+        public var error: String?
         public var message: String
         public var stacktrace: String?
     }

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -51,7 +51,7 @@ class APIToRequestMappingTests: XCTestCase {
             XCTAssertEqual($0.value, "myElement.name")
             return ResponseWithValue(.init(element: "myElement"))
         }
-        XCTAssertNotNil(try session.findElement(locator: .name("myElement.name")))
+        try session.requireElement(locator: .name("myElement.name"))
 
         mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Requests.SessionActiveElement.self) {
             ResponseWithValue(.init(element: "myElement"))

--- a/Tests/WinAppDriverTests/MSInfo32App.swift
+++ b/Tests/WinAppDriverTests/MSInfo32App.swift
@@ -13,28 +13,28 @@ class MSInfo32App {
     }
 
     private lazy var _maximizeButton = Result {
-        try XCTUnwrap(session.findElement(locator: .name("Maximize")), "Maximize button not found")
+        try session.requireElement(locator: .name("Maximize"), description: "Maximize window button")
     }
     var maximizeButton: Element {
         get throws { try _maximizeButton.get() }
     }
 
     private lazy var _systemSummaryTree = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("201")), "System summary tree control not found")
+        try session.requireElement(locator: .accessibilityId("201"), description: "System summary tree control")
     }
     var systemSummaryTree: Element {
         get throws { try _systemSummaryTree.get() }
     }
 
     private lazy var _findWhatEditBox = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("204")), "'Find what' edit box not found")
+        try session.requireElement(locator: .accessibilityId("204"), description: "'Find what' edit box")
     }
     var findWhatEditBox: Element {
         get throws { try _findWhatEditBox.get() }
     }
 
     private lazy var _searchSelectedCategoryOnlyCheckbox = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("206")), "'Search selected category only' checkbox not found")
+        try session.requireElement(locator: .accessibilityId("206"), description: "'Search selected category only' checkbox")
     }
     var searchSelectedCategoryOnlyCheckbox: Element {
         get throws { try _searchSelectedCategoryOnlyCheckbox.get() }


### PR DESCRIPTION
`Session/Element.findElement` is an outlier in that it is the only method that converts a specific error (element not found) into a nil value. It is also prone to misuse since it makes it perfectly sensible to test for `findElement(...) == nil`, without realizing that this incurs the worst-case implicit wait, which may not be desirable for such negative tests.

In contrast, `requireElement` throws upon failure, which makes it directly usable in positive tests (where the element should exist), with the best-case implicit wait and without having to unwrap the result.

Since a pattern is to call `findElement` in an `XCTUnwrap` and provide a description of the item that was not found, `requireElement` takes an optional description and always throws the same error type which captures all relevant information for diagnostics.

Alternate names considered:
- `expectElement` (sounds too much like a test framework)
- `getElement` (too subtly different from `findElement`, could still imply a nullable return)
- `findElement`, and make the other one `tryFindElement` (too C#-y)

Possible follow-ups: make the `waitTimeout` parameter of `findElement` non-optional to call out the waiting pitfall when used in negative tests.