### PR TITLE
Make Session/Element.findElement throwing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,10 +11,10 @@ A Swift library for UI automation of apps and browsers via communication with [W
 A `swift-webdriver` "Hello world" using `WinAppDriver` might look like this:
 
 ```swift
-let session = Session(
+let session = try Session(
     webDriver: WinAppDriver.start(), // Requires WinAppDriver to be installed on the machine
     desiredCapabilities: WinAppDriver.Capabilities.startApp(name: "notepad.exe"))
-session.findElement(locator: .name("close"))?.click()
+try session.requireElement(locator: .name("close")).click()
 ```
 
 To use `swift-webdriver` in your project, add a reference to it in your `Package.swift` file as follows:

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ A `swift-webdriver` "Hello world" using `WinAppDriver` might look like this:
 let session = try Session(
     webDriver: WinAppDriver.start(), // Requires WinAppDriver to be installed on the machine
     desiredCapabilities: WinAppDriver.Capabilities.startApp(name: "notepad.exe"))
-try session.requireElement(locator: .name("close")).click()
+try session.findElement(locator: .name("close")).click()
 ```
 
 To use `swift-webdriver` in your project, add a reference to it in your `Package.swift` file as follows:

--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -2,12 +2,12 @@ add_library(WebDriver
   Capabilities.swift
   Element.swift
   ElementLocator.swift
-  ElementNotFoundError.swift
   ErrorResponse.swift
   HTTPWebDriver.swift
   Keys.swift
   Location.swift
   MouseButton.swift
+  NoSuchElementError.swift
   Poll.swift
   Request.swift
   Requests.swift

--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(WebDriver
   Capabilities.swift
   Element.swift
   ElementLocator.swift
+  ElementNotFoundError.swift
   ErrorResponse.swift
   HTTPWebDriver.swift
   Keys.swift

--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -86,26 +86,17 @@ public struct Element {
     /// - Parameter locator: The locator strategy to use.
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws -> Element? {
+    @discardableResult // for use as an assertion
+    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws -> Element {
         try session.findElement(startingAt: self, locator: locator, waitTimeout: waitTimeout)
     }
 
     /// Search for elements using a given locator, starting from this element.
     /// - Parameter using: The locator strategy to use.
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
-    /// - Returns: The elements that were found, if any.
+    /// - Returns: The elements that were found, or an empty array.
     public func findElements(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws -> [Element] {
         try session.findElements(startingAt: self, locator: locator, waitTimeout: waitTimeout)
-    }
-
-    /// Finds an element using a given locator, starting from this element, and throwing upon failure.
-    /// - Parameter locator: The locator strategy to use.
-    /// - Parameter description: A human-readable description of the element, included in thrown errors.
-    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
-    /// - Returns: The element that was found.
-    @discardableResult // for use as an assertion
-    public func requireElement(locator: ElementLocator, description: String? = nil, waitTimeout: TimeInterval? = nil) throws -> Element {
-        try session.requireElement(startingAt: self, locator: locator, description: description, waitTimeout: waitTimeout)
     }
 
     /// Gets an attribute of this element.

--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -98,6 +98,16 @@ public struct Element {
         try session.findElements(startingAt: self, locator: locator, waitTimeout: waitTimeout)
     }
 
+    /// Finds an element using a given locator, starting from this element, and throwing upon failure.
+    /// - Parameter locator: The locator strategy to use.
+    /// - Parameter description: A human-readable description of the element, included in thrown errors.
+    /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
+    /// - Returns: The element that was found.
+    @discardableResult // for use as an assertion
+    public func requireElement(locator: ElementLocator, description: String? = nil, waitTimeout: TimeInterval? = nil) throws -> Element {
+        try session.requireElement(startingAt: self, locator: locator, description: description, waitTimeout: waitTimeout)
+    }
+
     /// Gets an attribute of this element.
     /// - Parameter name: the attribute name.
     /// - Returns: the attribute value string.

--- a/Sources/WebDriver/ElementNotFoundError.swift
+++ b/Sources/WebDriver/ElementNotFoundError.swift
@@ -1,0 +1,19 @@
+public struct ElementNotFoundError: Error {
+    /// The locator that was used to search for the element.
+    public var locator: ElementLocator
+
+    /// A human-readable description of the element.
+    public var description: String?
+
+    /// The error that caused the element to not be found.
+    public var sourceError: Error
+
+    public init(locator: ElementLocator, description: String? = nil, sourceError: Error) {
+        self.locator = locator
+        self.description = description
+        self.sourceError = sourceError
+    }
+
+    /// The error response returned by the WebDriver server, if this was the source of the failure.
+    public var errorResponse: ErrorResponse? { sourceError as? ErrorResponse }
+}

--- a/Sources/WebDriver/ErrorResponse.swift
+++ b/Sources/WebDriver/ErrorResponse.swift
@@ -38,7 +38,7 @@ public struct ErrorResponse: Codable, Error {
     }
 
     public struct Value: Codable {
-        public var error: String
+        public var error: String?
         public var message: String
         public var stacktrace: String?
     }

--- a/Sources/WebDriver/NoSuchElementError.swift
+++ b/Sources/WebDriver/NoSuchElementError.swift
@@ -1,19 +1,20 @@
-public struct ElementNotFoundError: Error {
+/// Thrown when findElement fails to locate an element.
+public struct ElementNotFoundError: Error, CustomStringConvertible {
     /// The locator that was used to search for the element.
     public var locator: ElementLocator
-
-    /// A human-readable description of the element.
-    public var description: String?
 
     /// The error that caused the element to not be found.
     public var sourceError: Error
 
-    public init(locator: ElementLocator, description: String? = nil, sourceError: Error) {
+    public init(locator: ElementLocator, sourceError: Error) {
         self.locator = locator
-        self.description = description
         self.sourceError = sourceError
     }
 
     /// The error response returned by the WebDriver server, if this was the source of the failure.
     public var errorResponse: ErrorResponse? { sourceError as? ErrorResponse }
+
+    public var description: String {
+        "Element not found using locator [\(locator.using)=\(locator.value)]: \(sourceError)"
+    }
 }

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -51,7 +51,7 @@ class APIToRequestMappingTests: XCTestCase {
             XCTAssertEqual($0.value, "myElement.name")
             return ResponseWithValue(.init(element: "myElement"))
         }
-        try session.requireElement(locator: .name("myElement.name"))
+        try session.findElement(locator: .name("myElement.name"))
 
         mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Requests.SessionActiveElement.self) {
             ResponseWithValue(.init(element: "myElement"))

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -51,7 +51,7 @@ class APIToRequestMappingTests: XCTestCase {
             XCTAssertEqual($0.value, "myElement.name")
             return ResponseWithValue(.init(element: "myElement"))
         }
-        XCTAssertNotNil(try session.findElement(locator: .name("myElement.name")))
+        try session.requireElement(locator: .name("myElement.name"))
 
         mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Requests.SessionActiveElement.self) {
             ResponseWithValue(.init(element: "myElement"))

--- a/Tests/WinAppDriverTests/MSInfo32App.swift
+++ b/Tests/WinAppDriverTests/MSInfo32App.swift
@@ -13,28 +13,28 @@ class MSInfo32App {
     }
 
     private lazy var _maximizeButton = Result {
-        try XCTUnwrap(session.findElement(locator: .name("Maximize")), "Maximize button not found")
+        try session.requireElement(locator: .name("Maximize"), description: "Maximize window button")
     }
     var maximizeButton: Element {
         get throws { try _maximizeButton.get() }
     }
 
     private lazy var _systemSummaryTree = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("201")), "System summary tree control not found")
+        try session.requireElement(locator: .accessibilityId("201"), description: "System summary tree control")
     }
     var systemSummaryTree: Element {
         get throws { try _systemSummaryTree.get() }
     }
 
     private lazy var _findWhatEditBox = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("204")), "'Find what' edit box not found")
+        try session.requireElement(locator: .accessibilityId("204"), description: "'Find what' edit box")
     }
     var findWhatEditBox: Element {
         get throws { try _findWhatEditBox.get() }
     }
 
     private lazy var _searchSelectedCategoryOnlyCheckbox = Result {
-        try XCTUnwrap(session.findElement(locator: .accessibilityId("206")), "'Search selected category only' checkbox not found")
+        try session.requireElement(locator: .accessibilityId("206"), description: "'Search selected category only' checkbox")
     }
     var searchSelectedCategoryOnlyCheckbox: Element {
         get throws { try _searchSelectedCategoryOnlyCheckbox.get() }

--- a/Tests/WinAppDriverTests/MSInfo32App.swift
+++ b/Tests/WinAppDriverTests/MSInfo32App.swift
@@ -13,28 +13,28 @@ class MSInfo32App {
     }
 
     private lazy var _maximizeButton = Result {
-        try session.requireElement(locator: .name("Maximize"), description: "Maximize window button")
+        try session.findElement(locator: .name("Maximize"))
     }
     var maximizeButton: Element {
         get throws { try _maximizeButton.get() }
     }
 
     private lazy var _systemSummaryTree = Result {
-        try session.requireElement(locator: .accessibilityId("201"), description: "System summary tree control")
+        try session.findElement(locator: .accessibilityId("201"))
     }
     var systemSummaryTree: Element {
         get throws { try _systemSummaryTree.get() }
     }
 
     private lazy var _findWhatEditBox = Result {
-        try session.requireElement(locator: .accessibilityId("204"), description: "'Find what' edit box")
+        try session.findElement(locator: .accessibilityId("204"))
     }
     var findWhatEditBox: Element {
         get throws { try _findWhatEditBox.get() }
     }
 
     private lazy var _searchSelectedCategoryOnlyCheckbox = Result {
-        try session.requireElement(locator: .accessibilityId("206"), description: "'Search selected category only' checkbox")
+        try session.findElement(locator: .accessibilityId("206"))
     }
     var searchSelectedCategoryOnlyCheckbox: Element {
         get throws { try _searchSelectedCategoryOnlyCheckbox.get() }

--- a/Tests/WinAppDriverTests/RequestsTests.swift
+++ b/Tests/WinAppDriverTests/RequestsTests.swift
@@ -78,14 +78,15 @@ class RequestsTests: XCTestCase {
         // ☃: Unicode BMP character
         let str = "kKł☃"
         try app.findWhatEditBox.sendKeys(Keys.text(str, typingStrategy: .windowsKeyboardAgnostic))
+
         // Normally we should be able to read the text back immediately,
         // but the MSInfo32 "Find what" edit box seems to queue events
         // such that WinAppDriver returns before they are fully processed.
-        XCTAssertEqual(
-            try poll(timeout: 0.5) {
-                let text = try app.findWhatEditBox.text
-                return PollResult(value: text, success: text == str)
-            }.value, str)
+        struct UnexpectedText: Error { var text: String }
+        _ = try poll(timeout: 0.5) {
+            let text = try app.findWhatEditBox.text
+            return text == str ? .success(()) : .failure(UnexpectedText(text: text))
+        }
     }
 
     func testSendKeysWithAcceleratorsGivesFocus() throws {

--- a/Tests/WinAppDriverTests/TimeoutTests.swift
+++ b/Tests/WinAppDriverTests/TimeoutTests.swift
@@ -36,9 +36,11 @@ class TimeoutTests: XCTestCase {
 
     static func measureNoSuchElementTime(_ session: Session) -> Double {
         measureTime {
-            XCTAssertThrowsError({
+            do {
                 try session.findElement(locator: .accessibilityId("IdThatDoesNotExist"))
-            })
+                XCTFail("Expected a no such element error")
+            }
+            catch {}
         }
     }
 


### PR DESCRIPTION
New approach from #157 : Other Selenium bindings (Java, C#) have a throwing `findElement` method, so do the same for Swift.

Also refactors `poll` to remove the `PollResult` type in favor of having the closure return a `Result<Value, Error>`. A returned error allows a retry whereas a thrown error stops the polling.