### PR TITLE
Introduce Keys.sequence

### DIFF
--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -108,13 +108,6 @@ public struct Element {
     }
 
     /// Sends key presses to this element.
-    /// - Parameter keys: An array of key sequences according to the WebDriver spec.
-    public func sendKeys(_ keys: [Keys]) throws {
-        try webDriver.send(Requests.ElementValue(
-            session: session.id, element: id, value: keys.map { $0.rawValue }))
-    }
-
-    /// Sends key presses to this element.
     /// - Parameter keys: A key sequence according to the WebDriver spec.
     public func sendKeys(_ keys: Keys) throws {
         try webDriver.send(Requests.ElementValue(

--- a/Sources/WebDriver/Keys.swift
+++ b/Sources/WebDriver/Keys.swift
@@ -1,11 +1,23 @@
 /// Represents a sequence of WebDriver key events and characters.
 public struct Keys: RawRepresentable {
+    /// A string encoding the key sequence as defined by the WebDriver spec.
     public var rawValue: String
 
     public init(rawValue: String) { self.rawValue = rawValue }
 
-    public static func +(lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue + rhs.rawValue) }
+    /// Concatenates multiple key sequences into a single one.
+    public static func sequence(_ keys: [Self]) -> Self {
+        Self(rawValue: keys.map(\.rawValue).joined())
+    }
 
+    /// Concatenates multiple key sequences into a single one.
+    public static func sequence(_ keys: Self...) -> Self {
+        sequence(keys)
+    }
+}
+
+// MARK: Key constants
+extension Keys {
     public static let a = Self(rawValue: "a")
     public static let b = Self(rawValue: "b")
     public static let c = Self(rawValue: "c")
@@ -109,47 +121,30 @@ public struct Keys: RawRepresentable {
     public static let releaseModifiers = Keys(rawValue: "\u{E000}")
 }
 
+// MARK: Modifier sequences
 extension Keys {
     /// Wraps a keys sequence with holding and releasing the shift key.
     public static func shift(_ keys: Self) -> Self {
-        Self(rawValue: "\(shiftModifier.rawValue)\(keys.rawValue)\(shiftModifier.rawValue)")
+        sequence(shiftModifier, keys, shiftModifier)
     }
 
     /// Wraps a keys sequence with holding and releasing the control key.
     public static func control(_ keys: Self) -> Self {
-        Self(rawValue: "\(controlModifier.rawValue)\(keys.rawValue)\(controlModifier.rawValue)")
+        sequence(controlModifier, keys, controlModifier)
     }
 
     /// Wraps a keys sequence with holding and releasing the alt key.
     public static func alt(_ keys: Self) -> Self {
-        Self(rawValue: "\(altModifier.rawValue)\(keys.rawValue)\(altModifier.rawValue)")
+        sequence(altModifier, keys, altModifier)
     }
 
     /// Wraps a keys sequence with holding and releasing the meta key.
     public static func meta(_ keys: Self) -> Self {
-        Self(rawValue: "\(metaModifier.rawValue)\(keys.rawValue)\(metaModifier.rawValue)")
-    }
-
-    /// Wraps a keys sequence with holding and releasing modifier keys.
-    public static func combo(_ keys: Self, shift: Bool = false, control: Bool = false, alt: Bool = false, meta: Bool = false) -> Self {
-        var rawValue = ""
-
-        if shift { rawValue += shiftModifier.rawValue }
-        if control { rawValue += controlModifier.rawValue }
-        if alt { rawValue += altModifier.rawValue }
-        if meta { rawValue += metaModifier.rawValue }
-
-        rawValue += keys.rawValue
-
-        if meta { rawValue += metaModifier.rawValue }
-        if alt { rawValue += altModifier.rawValue }
-        if control { rawValue += controlModifier.rawValue }
-        if shift { rawValue += shiftModifier.rawValue }
-
-        return Self(rawValue: rawValue)
+        sequence(metaModifier, keys, metaModifier)
     }
 }
 
+// MARK: Text and typing
 extension Keys {
     public enum TypingStrategy {
         case assumeUSKeyboard

--- a/Sources/WebDriver/Keys.swift
+++ b/Sources/WebDriver/Keys.swift
@@ -7,7 +7,7 @@ public struct Keys: RawRepresentable {
 
     /// Concatenates multiple key sequences into a single one.
     public static func sequence(_ keys: [Self]) -> Self {
-        Self(rawValue: keys.map(\.rawValue).joined())
+        Self(rawValue: keys.reduce("") { $0 + $1.rawValue })
     }
 
     /// Concatenates multiple key sequences into a single one.

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -283,15 +283,6 @@ public class Session {
     }
 
     /// Sends key presses to this session.
-    /// - Parameter keys: An array of key sequences according to the WebDriver spec.
-    /// - Parameter releaseModifiers: A boolean indicating whether to release modifier keys at the end of the sequence.
-    public func sendKeys(_ keys: [Keys], releaseModifiers: Bool = true) throws {
-        var value = keys.map { $0.rawValue }
-        if releaseModifiers { value.append(Keys.releaseModifiers.rawValue) }
-        try webDriver.send(Requests.SessionKeys(session: id, value: value))
-    }
-
-    /// Sends key presses to this session.
     /// - Parameter keys: A key sequence according to the WebDriver spec.
     /// - Parameter releaseModifiers: A boolean indicating whether to release modifier keys at the end of the sequence.
     public func sendKeys(_ keys: Keys, releaseModifiers: Bool = true) throws {

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -123,15 +123,15 @@ class APIToRequestMappingTests: XCTestCase {
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
 
-        let keys = [ Keys.a, Keys.b, Keys.c ]
+        let keys = Keys.sequence(.a, .b, .c)
         mockWebDriver.expect(path: "session/mySession/keys", method: .post, type: Requests.SessionKeys.self) {
-            XCTAssertEqual($0.value, keys.map { $0.rawValue })
+            XCTAssertEqual($0.value.first, keys.rawValue)
             return CodableNone()
         }
         try session.sendKeys(keys, releaseModifiers: false)
 
         mockWebDriver.expect(path: "session/mySession/element/myElement/value", method: .post, type: Requests.ElementValue.self) {
-            XCTAssertEqual($0.value, keys.map { $0.rawValue })
+            XCTAssertEqual($0.value.first, keys.rawValue)
             return CodableNone()
         }
         try element.sendKeys(keys)

--- a/Tests/WinAppDriverTests/MSInfo32App.swift
+++ b/Tests/WinAppDriverTests/MSInfo32App.swift
@@ -2,8 +2,8 @@
 import XCTest
 
 class MSInfo32App {
-    static let findWhatEditBoxAccelerator = Keys.alt(Keys.w)
-    static let searchSelectedCategoryOnlyCheckboxAccelerator = Keys.alt(Keys.s)
+    static let findWhatEditBoxAccelerator = Keys.alt(.w)
+    static let searchSelectedCategoryOnlyCheckboxAccelerator = Keys.alt(.s)
 
     let session: Session
 

--- a/Tests/WinAppDriverTests/RequestsTests.swift
+++ b/Tests/WinAppDriverTests/RequestsTests.swift
@@ -82,7 +82,7 @@ class RequestsTests: XCTestCase {
         // ł: Not typeable on a US Keyboard
         // ☃: Unicode BMP character
         let str = "kKł☃"
-        try app.findWhatEditBox.sendKeys(Keys.text(str, typingStrategy: .windowsKeyboardAgnostic))
+        try app.findWhatEditBox.sendKeys(.text(str, typingStrategy: .windowsKeyboardAgnostic))
 
         // Normally we should be able to read the text back immediately,
         // but the MSInfo32 "Find what" edit box seems to queue events
@@ -97,40 +97,40 @@ class RequestsTests: XCTestCase {
     func testSendKeysWithAcceleratorsGivesFocus() throws {
         try app.session.sendKeys(MSInfo32App.findWhatEditBoxAccelerator)
         try XCTAssert(Self.hasKeyboardFocus(app.findWhatEditBox))
-        try app.session.sendKeys(Keys.tab)
+        try app.session.sendKeys(.tab)
         try XCTAssert(!Self.hasKeyboardFocus(app.findWhatEditBox))
     }
 
     func testSessionSendKeys_scopedModifiers() throws {
         try app.findWhatEditBox.click()
-        try app.session.sendKeys(Keys.shift(Keys.a) + Keys.a)
+        try app.session.sendKeys(.sequence(.shift(.a), .a))
         XCTAssertEqual(try app.findWhatEditBox.text, "Aa")
     }
 
     func testSessionSendKeys_autoReleasedModifiers() throws {
         try app.findWhatEditBox.click()
-        try app.session.sendKeys(Keys.shiftModifier + Keys.a)
-        try app.session.sendKeys(Keys.a)
+        try app.session.sendKeys(.sequence(.shiftModifier, .a))
+        try app.session.sendKeys(.a)
         XCTAssertEqual(try app.findWhatEditBox.text, "Aa")
     }
 
     func testSessionSendKeys_stickyModifiers() throws {
         try app.findWhatEditBox.click()
-        try app.session.sendKeys(Keys.shiftModifier + Keys.a, releaseModifiers: false)
-        try app.session.sendKeys(Keys.a)
+        try app.session.sendKeys(.sequence(.shiftModifier, .a), releaseModifiers: false)
+        try app.session.sendKeys(.a)
         try app.session.sendKeys(.releaseModifiers)
-        try app.session.sendKeys(Keys.a)
+        try app.session.sendKeys(.a)
         XCTAssertEqual(try app.findWhatEditBox.text, "AAa")
     }
 
     func testElementSendKeys_scopedModifiers() throws {
-        try app.findWhatEditBox.sendKeys(Keys.shift(Keys.a) + Keys.a)
+        try app.findWhatEditBox.sendKeys(.sequence(.shift(.a), .a))
         XCTAssertEqual(try app.findWhatEditBox.text, "Aa")
     }
 
     func testElementSendKeys_autoReleasedModifiers() throws {
-        try app.findWhatEditBox.sendKeys(Keys.shiftModifier + Keys.a)
-        try app.findWhatEditBox.sendKeys(Keys.a)
+        try app.findWhatEditBox.sendKeys(.sequence(.shiftModifier, .a))
+        try app.findWhatEditBox.sendKeys(.a)
         XCTAssertEqual(try app.findWhatEditBox.text, "Aa")
     }
 


### PR DESCRIPTION
- Removes `Keys.operator+` as it could be confused with "hold <lhs> and press <rhs>" in favor of an explicit `Keys.sequence(...)` function.
- Removes `sendKeys` overloads taking a Keys array. The array variant is supported by the protocol, but the spec says "The server should flatten the array items to a single string to be typed.", so let's rather encourage the use `Keys.sequence`. If a client really needs to send a key array, they can drop down to `webDriver.send(Requests.SessionKeys(...))`.
- Removes `.combo`, which was unused and assumed a certain ordering of modifiers that is better expressed in the client code.

Fixes #163