### PR TITLE
Update & pin GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,14 +14,14 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Swift-WebBrowser
-      uses: actions/checkout@v4.1.1
+    - name: Checkout repo
+      uses: actions/checkout@v4.2.2
 
     - name: Setup Visual Studio Development Environment
-      uses: compnerd/gha-setup-vsdevenv@main
+      uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main as of 2024-11-12
 
     - name: Install Swift
-      uses: compnerd/gha-setup-swift@main
+      uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
       with:
         branch: swift-5.8-release
         tag: 5.8-RELEASE
@@ -38,15 +38,14 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Checkout Swift-WebBrowser
-        uses: actions/checkout@v4.1.1
+      - name: Checkout repo
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Visual Studio Development Environment
         uses: compnerd/gha-setup-vsdevenv@main
 
       - name: Install Swift
-        # TODO: Use mainline version once linker issue is fixed.
-        uses: compnerd/gha-setup-swift@8f43ccc3e8bac89829862af09de9567c807c1c12
+        uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
         with:
           branch: swift-5.8-release
           tag: 5.8-RELEASE


### PR DESCRIPTION
Update GitHub actions to the current latest and pin them for build reproducibility.

Fixes #146