### PR TITLE
Tweak workflows to avoid double builds on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,11 +1,13 @@
 name: Build & Test
 
 on:
-  push:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build-spm:


### PR DESCRIPTION
I think we were running the build workflow for any branch pushed as well as PRs, which resulted in redundant builds (one for the PR, one for the push to its branch). With this change, PRs only run each build (SPM and CMake) once. Compare with any previous PR, such as #165.