### PR TITLE
Gate PRs on build success

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,3 +59,13 @@ jobs:
       - name: CMake Build
         shell: pwsh
         run: cmake --build .\build
+
+  go-no-go: # Required status check
+    name: Go/No-Go
+    needs: [build-spm, build-cmake]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed
+        if: contains(needs.*.result, 'failure')
+        run: exit 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,8 +60,8 @@ jobs:
         shell: pwsh
         run: cmake --build .\build
 
-  go-no-go: # Required status check
-    name: Go/No-Go
+  merge-policy: # Required status check
+    name: Merge Policy
     needs: [build-spm, build-cmake]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
I just merged [this PR](https://github.com/thebrowsercompany/swift-webdriver/pull/164) before the workflows completed, and realized that this repo doesn't have required checks. Since required checks are matched by name and difficult to version with GitHub Actions, this adds a single last job that will be the only required check and can have a stable name over time.