### PR TITLE
Avoid assertion failures in deinitializers

### DIFF
--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -363,11 +363,6 @@ public class Session {
     }
 
     deinit {
-        do { try delete() }
-        catch let error as ErrorResponse {
-            assertionFailure("Error in Session.delete: \(error)")
-        } catch {
-            assertionFailure("Unexpected error in Session.delete: \(error)")
-        }
+        try? delete() // Call `delete` directly to handle errors.
     }
 }


### PR DESCRIPTION
There may be cases where a clean deinitialization is impossible. We should not assert in the deinit because it will always force the program to terminate in debug builds. Rather swallow errors and provide a way to handle them before deinit.