### PR TITLE
Early W3C protocol and Appium support

### DIFF
--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -19,4 +19,5 @@ add_library(WebDriver
   URLRequestExtensions.swift
   WebDriver.swift
   WebDriverStatus.swift
-  Window.swift)
+  Window.swift
+  WireProtocol.swift)

--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(WebDriver
   Capabilities.swift
+  Capabilities+AppiumOptions.swift
   Element.swift
   ElementLocator.swift
   ErrorResponse.swift

--- a/Sources/WebDriver/Capabilities+AppiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+AppiumOptions.swift
@@ -1,0 +1,32 @@
+extension Capabilities {
+    /// Appium-specific capabilities. See https://appium.io/docs/en/2.0/guides/caps
+    open class AppiumOptions: Codable {
+        public var app: String? = nil
+        public var appArguments: [String]? = nil
+        public var appWorkingDir: String? = nil
+        public var automationName: String? = nil
+        public var deviceName: String? = nil
+        public var eventTimings: Bool? = nil
+        public var fullReset: Bool? = nil
+        public var newCommandTimeout: Double? = nil
+        public var noReset: Bool? = nil
+        public var platformVersion: String? = nil
+        public var printPageSourceOnFindFailure: Bool? = nil
+
+        public init() {}
+
+        private enum CodingKeys: String, CodingKey {
+            case app
+            case appArguments
+            case appWorkingDir
+            case automationName
+            case deviceName
+            case eventTimings
+            case fullReset
+            case newCommandTimeout
+            case noReset
+            case platformVersion
+            case printPageSourceOnFindFailure
+        }
+    }
+}

--- a/Sources/WebDriver/Capabilities.swift
+++ b/Sources/WebDriver/Capabilities.swift
@@ -8,6 +8,9 @@ open class Capabilities: Codable {
     public var takesScreenshot: Bool?
     public var nativeEvents: Bool?
 
+    // From https://appium.io/docs/en/2.0/guides/caps
+    public var appiumOptions: AppiumOptions?
+
     public init() {}
 
     // See https://www.w3.org/TR/webdriver1/#dfn-table-of-session-timeouts
@@ -24,6 +27,8 @@ open class Capabilities: Codable {
 
         case takesScreenshot
         case nativeEvents
+
+        case appiumOptions = "appium:options"
     }
 }
 

--- a/Sources/WebDriver/HTTPWebDriver.swift
+++ b/Sources/WebDriver/HTTPWebDriver.swift
@@ -3,17 +3,18 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// A connection to a WebDriver server over HTTP.
 public struct HTTPWebDriver: WebDriver {
     let rootURL: URL
+    public let wireProtocol: WireProtocol
 
     public static let defaultRequestTimeout: TimeInterval = 5 // seconds
 
-    public init(endpoint: URL) {
+    public init(endpoint: URL, wireProtocol: WireProtocol) {
         rootURL = endpoint
+        self.wireProtocol = wireProtocol
     }
 
-    // Send a Request to the web driver local service
-    // TODO: consider making this function async/awaitable
     @discardableResult
     public func send<Req: Request>(_ request: Req) throws -> Req.Response {
         let urlRequest = try buildURLRequest(request)

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -160,7 +160,7 @@ public enum Requests {
         public typealias Response = ResponseWithValue<String>
     }
 
-    public struct Session<Caps: Capabilities>: Request {
+    public struct Session_Legacy<Caps: Capabilities>: Request {
         public var desiredCapabilities: Caps
         public var requiredCapabilities: Caps?
 
@@ -181,6 +181,36 @@ public enum Requests {
         public struct Response: Codable {
             public var sessionId: String
             public var value: Caps
+        }
+    }
+
+    public struct Session_W3C<Caps: Capabilities>: Request {
+        public var alwaysMatch: Caps
+        public var firstMatch: [Caps]
+
+        public init(alwaysMatch: Caps, firstMatch: [Caps] = []) {
+            self.alwaysMatch = alwaysMatch
+            self.firstMatch = firstMatch
+        }
+
+        public var pathComponents: [String] { ["session"] }
+        public var method: HTTPMethod { .post }
+        public var body: Body { .init(capabilities: .init(alwaysMatch: alwaysMatch, firstMatch: firstMatch)) }
+
+        public struct Body: Codable {
+            public struct Capabilities: Codable {
+                public var alwaysMatch: Caps
+                public var firstMatch: [Caps]?
+            }
+
+            public var capabilities: Capabilities
+        }
+
+        public typealias Response = ResponseWithValue<ResponseValue>
+
+        public struct ResponseValue: Codable {
+            public var sessionId: String
+            public var capabilities: Caps
         }
     }
 

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -21,9 +21,23 @@ public class Session {
     }
 
     public convenience init(webDriver: any WebDriver, desiredCapabilities: Capabilities, requiredCapabilities: Capabilities? = nil) throws {
-        let response = try webDriver.send(Requests.Session(
+        let response = try webDriver.send(Requests.Session_Legacy(
             desiredCapabilities: desiredCapabilities, requiredCapabilities: requiredCapabilities))
-        self.init(webDriver: webDriver, existingId: response.sessionId, capabilities: response.value, owned: true)
+        self.init(
+            webDriver: webDriver,
+            existingId: response.sessionId,
+            capabilities: response.value,
+            owned: true)
+    }
+
+    public static func createW3C(webDriver: any WebDriver, alwaysMatch: Capabilities, firstMatch: [Capabilities] = []) throws -> Session {
+        let response = try webDriver.send(Requests.Session_W3C(
+            alwaysMatch: alwaysMatch, firstMatch: firstMatch))
+        return Session(
+            webDriver: webDriver,
+            existingId: response.value.sessionId,
+            capabilities: response.value.capabilities,
+            owned: true)
     }
 
     /// The amount of time the driver should implicitly wait when searching for elements.

--- a/Sources/WebDriver/WebDriver.swift
+++ b/Sources/WebDriver/WebDriver.swift
@@ -1,4 +1,9 @@
 public protocol WebDriver {
+    /// The protocol supported by the WebDriver server.
+    var wireProtocol: WireProtocol { get }
+
+    /// Sends a WebDriver request to the server and returns the response.
+    /// - Parameter request: The request to send.
     @discardableResult
     func send<Req: Request>(_ request: Req) throws -> Req.Response
 

--- a/Sources/WebDriver/WireProtocol.swift
+++ b/Sources/WebDriver/WireProtocol.swift
@@ -1,0 +1,8 @@
+public enum WireProtocol {
+    /// Identifiers Selenium's Legacy JSON Wire Protocol, 
+    /// Documented at: https://www.selenium.dev/documentation/legacy/json_wire_protocol
+    case legacySelenium
+    /// Identifiers the W3C WebDriver Protocol,
+    /// Documented at: https://w3c.github.io/webdriver/webdriver-spec.html
+    case w3c
+}

--- a/Sources/WinAppDriver/WinAppDriver.swift
+++ b/Sources/WinAppDriver/WinAppDriver.swift
@@ -32,7 +32,7 @@ public class WinAppDriver: WebDriver {
     }
 
     public static func attach(ip: String = defaultIp, port: Int = defaultPort) -> WinAppDriver {
-        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!)
+        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
         return WinAppDriver(httpWebDriver: httpWebDriver)
     }
 
@@ -96,7 +96,7 @@ public class WinAppDriver: WebDriver {
             throw StartError(message: "Call to Win32 \(error.apiName) failed with error code \(error.errorCode).")
         }
 
-        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!)
+        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
 
         // Give WinAppDriver some time to start up
         if let waitTime {
@@ -117,6 +117,8 @@ public class WinAppDriver: WebDriver {
     deinit {
         try? close() // Call close() directly to handle errors. 
     }
+
+    public var wireProtocol: WireProtocol { .legacySelenium }
 
     @discardableResult
     public func send<Req: Request>(_ request: Req) throws -> Req.Response {

--- a/Tests/AppiumTests/AppiumTests.swift
+++ b/Tests/AppiumTests/AppiumTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import WebDriver
+import XCTest
+
+final class AppiumTests: XCTestCase {
+    private var appiumServerURL: URL? = nil
+
+    override func setUpWithError() throws {
+        super.setUp()
+        appiumServerURL = ProcessInfo.processInfo.environment["APPIUM_SERVER_URL"].flatMap { URL(string: $0) }
+        try XCTSkipIf(appiumServerURL == nil, "APPIUM_SERVER_URL environment variable is not set.")
+    }
+
+#if os(Windows)
+    func testAppium() throws {
+        let webDriver = HTTPWebDriver(endpoint: appiumServerURL!, wireProtocol: .w3c)
+
+        let appiumOptions = Capabilities.AppiumOptions()
+        appiumOptions.automationName = "windows"
+        appiumOptions.app = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+
+        let capabilities = Capabilities()
+        capabilities.platformName = "windows"
+        capabilities.appiumOptions = appiumOptions
+
+        let session = try Session.createW3C(webDriver: webDriver, alwaysMatch: capabilities)
+        try session.sendKeys(.alt(.f4))
+    }
+#endif
+}

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -7,11 +7,11 @@ class APIToRequestMappingTests: XCTestCase {
     private typealias ResponseWithValue = Requests.ResponseWithValue
 
     func testCreateSession() throws {
-        let mockWebDriver = MockWebDriver()
-        mockWebDriver.expect(path: "session", method: .post, type: Requests.Session.self) {
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
+        mockWebDriver.expect(path: "session", method: .post, type: Requests.Session_Legacy.self) {
             let capabilities = Capabilities()
             capabilities.platformName = "myPlatform"
-            return Requests.Session.Response(sessionId: "mySession", value: capabilities)
+            return Requests.Session_Legacy.Response(sessionId: "mySession", value: capabilities)
         }
         let session = try Session(webDriver: mockWebDriver, desiredCapabilities: Capabilities())
         XCTAssertEqual(session.id, "mySession")
@@ -22,7 +22,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionTitle() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/title", method: .get) {
             ResponseWithValue("mySession.title")
@@ -34,7 +34,7 @@ class APIToRequestMappingTests: XCTestCase {
         let base64TestImage: String =
             "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAHCAYAAAA1WQxeAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAB2GAAAdhgFdohOBAAAABmJLR0QA/wD/AP+gvaeTAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDIzLTA3LTEzVDIwOjAxOjQ1KzAwOjAwCWqxhgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyMy0wNy0xM1QyMDowMTo0NSswMDowMHg3CToAAAC2SURBVBhXY/iPDG7c+///5y8oBwJQFRj4/P9f3QNhn78Appi+fP3LkNfxnIFh43oGBiE+BoYjZxkYHj5iYFi2goHhzVsGpoePfjBMrrzLUNT4jIEh2IaBQZCTgaF1EgODkiIDg4gwA9iKpILL/xnkL/xnkLzyv8UUaIVL2P//Xz5DrGAAgoPzVjDosRxmaG4UZxArjAAa/YGBYfdxkBTEhP37bv9/+eIDWAcYHDsHNOEbkPH/PwCcrZANcnx9SAAAAABJRU5ErkJggg=="
 
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/screenshot", method: .get) {
             ResponseWithValue(base64TestImage)
@@ -44,7 +44,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionFindElement() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Requests.SessionElement.self) {
             XCTAssertEqual($0.using, "name")
@@ -60,7 +60,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionMoveTo() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/moveto", method: .post, type: Requests.SessionMoveTo.self) {
@@ -73,7 +73,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionClick() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/click", method: .post, type: Requests.SessionButton.self) {
             XCTAssertEqual($0.button, .left)
@@ -83,7 +83,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionButton() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/buttondown", method: .post, type: Requests.SessionButton.self) {
             XCTAssertEqual($0.button, .right)
@@ -99,7 +99,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
  
     func testSessionOrientation() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/orientation", method: .post)
         try session.setOrientation(.portrait)
@@ -119,7 +119,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSendKeys() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
 
@@ -138,7 +138,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementText() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/text", method: .get) {
@@ -148,7 +148,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementAttribute() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/attribute/myAttribute.name", method: .get) {
@@ -158,7 +158,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementClick() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/click", method: .post)
@@ -166,7 +166,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementLocationAndSize() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/location", method: .get, type: Requests.ElementLocation.self) {
@@ -181,7 +181,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementEnabled() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/enabled", method: .get) {
@@ -191,7 +191,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementSelected() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/selected", method: .get) {
@@ -201,7 +201,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testWindowPosition() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/position", method: .post)
         try session.window(handle: "myWindow").setPosition(x: 9, y: 16)
@@ -213,21 +213,21 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionScript() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/execute", method: .post)
         XCTAssertNotNil(try session.execute(script: "return document.body", args: ["script"], async: false))
     }
 
     func testSessionScriptAsync() throws {
-        let mockWebDriver = MockWebDriver()
+        let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/execute_async", method: .post)
         XCTAssertNotNil(try session.execute(script: "return document.body", args: ["script"], async: true))
     }
 
     func testSessionTouchScroll() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/scroll", method: .post)
@@ -235,7 +235,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testWindow() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window", method: .post)
         try session.focus(window: "myWindow")
@@ -245,7 +245,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testWindowHandleSize() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/size", method: .post)
         try session.window(handle: "myWindow").setSize(width: 500, height: 500)
@@ -257,7 +257,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testLocation() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let location = Location(latitude: 5, longitude: 20, altitude: 2003)
         
@@ -271,14 +271,14 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testMaximizeWindow() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session: Session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/maximize", method: .post)
         try session.window(handle: "myWindow").maximize()
     }
 
     func testWindowHandle() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
 
         mockWebDriver.expect(path: "session/mySession/window_handle", method: .get, type: Requests.SessionWindowHandle.self) {
@@ -289,7 +289,7 @@ class APIToRequestMappingTests: XCTestCase {
 
     func testWindowHandles() throws {
 
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         
         mockWebDriver.expect(path: "session/mySession/window_handles", method: .get, type: Requests.SessionWindowHandles.self) {
@@ -300,7 +300,7 @@ class APIToRequestMappingTests: XCTestCase {
 
 
     func testElementDoubleClick() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/doubleclick", method: .post)
@@ -308,7 +308,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testElementFlick() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/flick", method: .post)
@@ -316,14 +316,14 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionFlick() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/touch/flick", method: .post)
         XCTAssertNotNil(try session.flick(xSpeed: 5, ySpeed: 20))
     }
 
     func testSessionSource() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/source", method: .get, type: Requests.SessionSource.self) {
             ResponseWithValue("currentSource")
@@ -332,7 +332,7 @@ class APIToRequestMappingTests: XCTestCase {
     }
 
     func testSessionTimeouts() throws {
-        let mockWebDriver: MockWebDriver = MockWebDriver()
+        let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/timeouts", method: .post)
         try session.setTimeout(type: .implicitWait, duration: 5)

--- a/Tests/UnitTests/MockWebDriver.swift
+++ b/Tests/UnitTests/MockWebDriver.swift
@@ -12,7 +12,12 @@ class MockWebDriver: WebDriver {
         let handler: (Data?) throws -> Data?
     }
 
+    let wireProtocol: WireProtocol
     var expectations: [Expectation] = []
+
+    public init(wireProtocol: WireProtocol) {
+        self.wireProtocol = wireProtocol
+    }
 
     deinit {
         // We should have met all of our expectations.


### PR DESCRIPTION
We developed `swift-webdriver` for use with `WinAppDriver`, so we only implemented support for the Selenium legacy JSON protocol. Other WebDriver servers like Appium use the W3C version of the protocol, which is similar but different, especially around initialization.

This change adds support for the W3C protocol and supports session creation using the W3C-compatible POST /session API. `WebDriver` instances now have an associated `wireProtocol` which is currently unused but will allow adapting requests based on the protocol used. The optional `Capabilities.appiumOptions` allows initializing an Appium session.

As a result, it's now possible to talk to an Appium server, as demonstrated by the new test.

Fixes #94

Future:
- #182
- #183
- #184
- #185
- #186