### PR TITLE
Update ElementResponseValue key to match W3C spec

### DIFF
--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -37,8 +37,8 @@ Contributions to expand support to unimplemented functionality are always welcom
 | GET    | `/session/:sessionId/element/:id/size`              | Supported    | `Element.size`      |
 | GET    | `/session/:sessionId/element/:id/text`              | Supported    | `Element.text`      |
 | POST   | `/session/:sessionId/element/:id/value`             | Supported    | `Element.sendKeys()`|
-| POST   | `/session/:sessionId/execute`                       | Not Supported| `Session.execute()` |
-| POST   | `/session/:sessionId/execute_async`                 | Not Supported| `Session.execute()` |
+| POST   | `/session/:sessionId/execute/sync`                  | Not Supported| `Session.execute()` |
+| POST   | `/session/:sessionId/execute/async`                 | Not Supported| `Session.execute()` |
 | POST   | `/session/:sessionId/forward`                       | Supported    | `Session.forward()` |
 | POST   | `/session/:sessionId/keys`                          | Supported    | `Session.sendKeys()`|
 | POST   | `/session/:sessionId/location`                      | Supported    | `Session.setLocation`|

--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -70,5 +70,5 @@ Contributions to expand support to unimplemented functionality are always welcom
 | POST   | `/session/:sessionId/window/:windowHandle/position` | Supported    | `Window.setPosition()`|
 | GET    | `/session/:sessionId/window/:windowHandle/position` | Supported    | `Window.position`|
 | POST   | `/session/:sessionId/window/:windowHandle/maximize` | Supported    | `Window.maximize()`|
-| GET    | `/session/:sessionId/window_handle`                 | Supported    | `Session.windowHandle`|
-| GET    | `/session/:sessionId/window_handles`                | Supported    | `Session.windowHandles`|
+| GET    | `/session/:sessionId/window`                        | Supported    | `Session.windowHandle`|
+| GET    | `/session/:sessionId/window/handles`                | Supported    | `Session.windowHandles`|

--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -44,6 +44,7 @@ Contributions to expand support to unimplemented functionality are always welcom
 | POST   | `/session/:sessionId/location`                      | Supported    | `Session.setLocation`|
 | GET    | `/session/:sessionId/location`                      | Supported    | `Session.location`|
 | POST   | `/session/:sessionId/moveto`                        | Supported    | `Session.moveTo()`  |
+| POST   | `/session/:sessionId/window/rect`                   | Supported    | `Session.setWindowRect()` |
 | GET    | `/session/:sessionId/orientation`                   | Supported    | `Session.orientation`|
 | POST   | `/session/:sessionId/refresh`                       | Not supported| `Session.refresh()` |
 | GET    | `/session/:sessionId/screenshot`                    | Supported    | `Session.screenshot()`|

--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -37,8 +37,8 @@ Contributions to expand support to unimplemented functionality are always welcom
 | GET    | `/session/:sessionId/element/:id/size`              | Supported    | `Element.size`      |
 | GET    | `/session/:sessionId/element/:id/text`              | Supported    | `Element.text`      |
 | POST   | `/session/:sessionId/element/:id/value`             | Supported    | `Element.sendKeys()`|
-| POST   | `/session/:sessionId/execute/sync`                  | Not Supported| `Session.execute()` |
-| POST   | `/session/:sessionId/execute/async`                 | Not Supported| `Session.execute()` |
+| POST   | `/session/:sessionId/execute/sync`                  | Supported    | `Session.execute()` |
+| POST   | `/session/:sessionId/execute/async`                 | Supported    | `Session.execute()` |
 | POST   | `/session/:sessionId/forward`                       | Supported    | `Session.forward()` |
 | POST   | `/session/:sessionId/keys`                          | Supported    | `Session.sendKeys()`|
 | POST   | `/session/:sessionId/location`                      | Supported    | `Session.setLocation`|

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,15 @@ import PackageDescription
 
 let package = Package(
     name: "swift-webdriver",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
-        .library(name: "WebDriver", targets: ["WebDriver"]),
-    ] + ifWindows([
-        .library(name: "WinAppDriver", targets: ["WinAppDriver"]),
-    ]),
+        .library(name: "WebDriver", targets: ["WebDriver"])
+    ]
+        + ifWindows([
+            .library(name: "WinAppDriver", targets: ["WinAppDriver"])
+        ]),
     targets: [
         .target(
             name: "WebDriver",
@@ -21,30 +25,33 @@ let package = Package(
             name: "UnitTests",
             dependencies: ["TestsCommon", "WebDriver"],
             // Ignore "LNK4217: locally defined symbol imported" spew due to SPM library support limitations
-            linkerSettings: [ .unsafeFlags(["-Xlinker", "-ignore:4217"], .when(platforms: [.windows])) ]),
-         .testTarget(
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-ignore:4217"], .when(platforms: [.windows]))
+            ]),
+        .testTarget(
             name: "AppiumTests",
             dependencies: ["TestsCommon", "WebDriver"],
             // Ignore "LNK4217: locally defined symbol imported" spew due to SPM library support limitations
-            linkerSettings: ifWindows([ .unsafeFlags(["-Xlinker", "-ignore:4217"]) ])),
-    ] + ifWindows([
-        .target(
-            name: "WinAppDriver",
-            dependencies: ["WebDriver"],
-            path: "Sources/WinAppDriver",
-            exclude: ["CMakeLists.txt"]),
-        .testTarget(
-            name: "WinAppDriverTests",
-            dependencies: ["TestsCommon", "WebDriver", "WinAppDriver"],
-            // Ignore "LNK4217: locally defined symbol imported" spew due to SPM library support limitations
-            linkerSettings: [ .unsafeFlags(["-Xlinker", "-ignore:4217"]) ]),
-    ])
+            linkerSettings: ifWindows([.unsafeFlags(["-Xlinker", "-ignore:4217"])])),
+    ]
+        + ifWindows([
+            .target(
+                name: "WinAppDriver",
+                dependencies: ["WebDriver"],
+                path: "Sources/WinAppDriver",
+                exclude: ["CMakeLists.txt"]),
+            .testTarget(
+                name: "WinAppDriverTests",
+                dependencies: ["TestsCommon", "WebDriver", "WinAppDriver"],
+                // Ignore "LNK4217: locally defined symbol imported" spew due to SPM library support limitations
+                linkerSettings: [.unsafeFlags(["-Xlinker", "-ignore:4217"])]),
+        ])
 )
 
 func ifWindows<T>(_ values: [T]) -> [T] {
     #if os(Windows)
-    return values
+        return values
     #else
-    return []
+        return []
     #endif
 }

--- a/Sources/WebDriver/BrowserSpecificOptions.swift
+++ b/Sources/WebDriver/BrowserSpecificOptions.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+open class BrowserSpecificOptions: Codable {
+    public init() {}
+
+    /// Creates a BrowserSpecificOptions instance from JSON args array.
+    /// - Parameter args: A JSON array representing the args list.
+    public static func create(with args: [Any]) throws -> BrowserSpecificOptions {
+        // We expect args to be an array of strings, convert it to JSON dictionary with key "args".
+        let dict: [String: Any] = ["args": args]
+
+        // Serialize to JSON Data
+        let jsonData = try JSONSerialization.data(withJSONObject: dict, options: [])
+
+        // Decode JSON into the concrete subclass using JSONDecoder.
+        // Because we cannot instantiate 'Self' here (static method),
+        // call decode on BrowserSpecificOptions by default, then cast or override in subclass if needed.
+        let decoder = JSONDecoder()
+        return try decoder.decode(Self.self, from: jsonData)
+    }
+
+    /// The list of command-line arguments for the browser.
+    public var args: [String] = []
+
+    private enum CodingKeys: String, CodingKey {
+        case args
+    }
+
+    // Required for Codable to decode `args`
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.args = try container.decode([String].self, forKey: .args)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(args, forKey: .args)
+    }
+}

--- a/Sources/WebDriver/CMakeLists.txt
+++ b/Sources/WebDriver/CMakeLists.txt
@@ -16,7 +16,6 @@ add_library(WebDriver
   Requests+W3C.swift
   ScreenOrientation.swift
   Session.swift
-  TimeoutType.swift
   TouchClickKind.swift
   URLRequestExtensions.swift
   WebDriver.swift

--- a/Sources/WebDriver/Capabilities+ChromeOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromeOptions.swift
@@ -1,0 +1,5 @@
+extension Capabilities {
+    /// Chrome-specific capabilities.
+    open class ChromeOptions: ChromiumOptions {
+    }
+}

--- a/Sources/WebDriver/Capabilities+ChromeOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromeOptions.swift
@@ -1,9 +1,5 @@
 extension Capabilities {
     /// Chrome-specific capabilities.
     open class ChromeOptions: ChromiumOptions {
-        public override var browserName: String? {
-            get { return "chrome" }
-            set {  }
-        }
     }
 }

--- a/Sources/WebDriver/Capabilities+ChromeOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromeOptions.swift
@@ -1,5 +1,9 @@
 extension Capabilities {
     /// Chrome-specific capabilities.
     open class ChromeOptions: ChromiumOptions {
+        public override var browserName: String? {
+            get { return "chrome" }
+            set {  }
+        }
     }
 }

--- a/Sources/WebDriver/Capabilities+ChromiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromiumOptions.swift
@@ -1,0 +1,12 @@
+extension Capabilities {
+    /// Chromium-specific capabilities.
+    open class ChromiumOptions: Codable {
+        public var binary: String? = nil
+
+        public init() {}
+
+        private enum CodingKeys: String, CodingKey {
+            case binary
+        }
+    }
+}

--- a/Sources/WebDriver/Capabilities+ChromiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromiumOptions.swift
@@ -7,5 +7,11 @@ extension Capabilities {
             case binary
             case args
         }
+
+        public override func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(binary, forKey: .binary)
+            try container.encode(args, forKey: .args)
+        }
     }
 }

--- a/Sources/WebDriver/Capabilities+ChromiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromiumOptions.swift
@@ -1,12 +1,11 @@
 extension Capabilities {
     /// Chromium-specific capabilities.
-    open class ChromiumOptions: Codable {
+    open class ChromiumOptions: BrowserSpecificOptions {
         public var binary: String? = nil
-
-        public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
+            case args
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+ChromiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromiumOptions.swift
@@ -2,13 +2,11 @@ extension Capabilities {
     /// Chromium-specific capabilities.
     open class ChromiumOptions: Codable {
         public var binary: String? = nil
-        public var browserName: String? = nil
 
         public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
-            case browserName
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+ChromiumOptions.swift
+++ b/Sources/WebDriver/Capabilities+ChromiumOptions.swift
@@ -2,11 +2,13 @@ extension Capabilities {
     /// Chromium-specific capabilities.
     open class ChromiumOptions: Codable {
         public var binary: String? = nil
+        public var browserName: String? = nil
 
         public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
+            case browserName
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+EdgeOptions.swift
+++ b/Sources/WebDriver/Capabilities+EdgeOptions.swift
@@ -1,8 +1,5 @@
 extension Capabilities {
     /// Edge-specific capabilities.
-    open class EdgeOptions: BrowserSpecificOptions {
-        private enum CodingKeys: String, CodingKey {
-            case args
-        }
+    open class EdgeOptions: ChromiumOptions {
     }
 }

--- a/Sources/WebDriver/Capabilities+EdgeOptions.swift
+++ b/Sources/WebDriver/Capabilities+EdgeOptions.swift
@@ -1,5 +1,8 @@
 extension Capabilities {
     /// Edge-specific capabilities.
-    open class EdgeOptions: ChromiumOptions {
+    open class EdgeOptions: BrowserSpecificOptions {
+        private enum CodingKeys: String, CodingKey {
+            case args
+        }
     }
 }

--- a/Sources/WebDriver/Capabilities+EdgeOptions.swift
+++ b/Sources/WebDriver/Capabilities+EdgeOptions.swift
@@ -1,0 +1,5 @@
+extension Capabilities {
+    /// Edge-specific capabilities.
+    open class EdgeOptions: ChromiumOptions {
+    }
+}

--- a/Sources/WebDriver/Capabilities+EdgeOptions.swift
+++ b/Sources/WebDriver/Capabilities+EdgeOptions.swift
@@ -1,5 +1,9 @@
 extension Capabilities {
     /// Edge-specific capabilities.
     open class EdgeOptions: ChromiumOptions {
+        public override var browserName: String? {
+            get { return "MicrosoftEdge" }
+            set {  }
+        }
     }
 }

--- a/Sources/WebDriver/Capabilities+EdgeOptions.swift
+++ b/Sources/WebDriver/Capabilities+EdgeOptions.swift
@@ -1,9 +1,5 @@
 extension Capabilities {
     /// Edge-specific capabilities.
     open class EdgeOptions: ChromiumOptions {
-        public override var browserName: String? {
-            get { return "MicrosoftEdge" }
-            set {  }
-        }
     }
 }

--- a/Sources/WebDriver/Capabilities+FirefoxOptions.swift
+++ b/Sources/WebDriver/Capabilities+FirefoxOptions.swift
@@ -2,11 +2,13 @@ extension Capabilities {
     /// Firefox-specific capabilities.
     open class FirefoxOptions: Codable {
         public var binary: String? = nil
+        public var browserName: String? = "firefox"
 
         public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
+            case browserName
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+FirefoxOptions.swift
+++ b/Sources/WebDriver/Capabilities+FirefoxOptions.swift
@@ -1,12 +1,11 @@
 extension Capabilities {
     /// Firefox-specific capabilities.
-    open class FirefoxOptions: Codable {
+    open class FirefoxOptions: BrowserSpecificOptions {
         public var binary: String? = nil
-
-        public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
+            case args
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+FirefoxOptions.swift
+++ b/Sources/WebDriver/Capabilities+FirefoxOptions.swift
@@ -7,5 +7,11 @@ extension Capabilities {
             case binary
             case args
         }
+
+        public override func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(binary, forKey: .binary)
+            try container.encode(args, forKey: .args)
+        }
     }
 }

--- a/Sources/WebDriver/Capabilities+FirefoxOptions.swift
+++ b/Sources/WebDriver/Capabilities+FirefoxOptions.swift
@@ -2,13 +2,11 @@ extension Capabilities {
     /// Firefox-specific capabilities.
     open class FirefoxOptions: Codable {
         public var binary: String? = nil
-        public var browserName: String? = "firefox"
 
         public init() {}
 
         private enum CodingKeys: String, CodingKey {
             case binary
-            case browserName
         }
     }
 }

--- a/Sources/WebDriver/Capabilities+FirefoxOptions.swift
+++ b/Sources/WebDriver/Capabilities+FirefoxOptions.swift
@@ -1,0 +1,12 @@
+extension Capabilities {
+    /// Firefox-specific capabilities.
+    open class FirefoxOptions: Codable {
+        public var binary: String? = nil
+
+        public init() {}
+
+        private enum CodingKeys: String, CodingKey {
+            case binary
+        }
+    }
+}

--- a/Sources/WebDriver/Capabilities.swift
+++ b/Sources/WebDriver/Capabilities.swift
@@ -11,6 +11,10 @@ open class Capabilities: Codable {
     // From https://appium.io/docs/en/2.0/guides/caps
     public var appiumOptions: AppiumOptions?
 
+    public var msEdgeOptions: EdgeOptions?
+    public var chromeOptions: ChromeOptions?
+    public var firefoxOptions: FirefoxOptions?
+    
     public init() {}
 
     // See https://www.w3.org/TR/webdriver1/#dfn-table-of-session-timeouts
@@ -29,6 +33,10 @@ open class Capabilities: Codable {
         case nativeEvents
 
         case appiumOptions = "appium:options"
+
+        case msEdgeOptions = "ms:edgeOptions"
+        case chromeOptions = "goog:chromeOptions"
+        case firefoxOptions = "moz:firefoxOptions"
     }
 }
 

--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -13,70 +13,84 @@ public struct Element {
 
     /// The element's textual contents.
     public var text: String {
-        get throws {
-            try webDriver.send(Requests.ElementText(
-                session: session.id, element: id)).value
+        get async throws {
+            try await webDriver.send(
+                Requests.ElementText(
+                    session: session.id, element: id)
+            ).value
         }
     }
 
     /// The x and y location of the element relative to the screen top left corner.
     public var location: (x: Int, y: Int) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.ElementLocation(
-                session: session.id, element: id)).value
+        get async throws {
+            let responseValue = try await webDriver.send(
+                Requests.ElementLocation(
+                    session: session.id, element: id)
+            ).value
             return (responseValue.x, responseValue.y)
         }
     }
 
     /// Gets the width and height of this element in pixels.
     public var size: (width: Int, height: Int) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.ElementSize(
-                session: session.id, element: id)).value
+        get async throws {
+            let responseValue = try await webDriver.send(
+                Requests.ElementSize(
+                    session: session.id, element: id)
+            ).value
             return (responseValue.width, responseValue.height)
         }
     }
 
     /// Gets a value indicating whether this element is currently displayed.
     public var displayed: Bool {
-        get throws {
-            try webDriver.send(Requests.ElementDisplayed(
-                session: session.id, element: id)).value
+        get async throws {
+            try await webDriver.send(
+                Requests.ElementDisplayed(
+                    session: session.id, element: id)
+            ).value
         }
     }
 
     /// Gets a value indicating whether this element is currently enabled.
     public var enabled: Bool {
-        get throws {
-            try webDriver.send(Requests.ElementEnabled(
-                session: session.id, element: id)).value
+        get async throws {
+            try await webDriver.send(
+                Requests.ElementEnabled(
+                    session: session.id, element: id)
+            ).value
         }
     }
 
     /// Gets a value indicating whether this element is currently selected.
     public var selected: Bool {
-        get throws {
-            try webDriver.send(Requests.ElementSelected(
-                session: session.id, element: id)).value
+        get async throws {
+            try await webDriver.send(
+                Requests.ElementSelected(
+                    session: session.id, element: id)
+            ).value
         }
     }
 
     /// Clicks this element.
-    public func click(retryTimeout: TimeInterval? = nil) throws {
+    public func click(retryTimeout: TimeInterval? = nil) async throws {
         let request = Requests.ElementClick(session: session.id, element: id)
-        try session.sendInteraction(request, retryTimeout: retryTimeout)
+        try await session.sendInteraction(request, retryTimeout: retryTimeout)
     }
 
     /// Clicks this element via touch.
-    public func touchClick(kind: TouchClickKind = .single, retryTimeout: TimeInterval? = nil) throws {
+    public func touchClick(kind: TouchClickKind = .single, retryTimeout: TimeInterval? = nil)
+        async throws
+    {
         let request = Requests.SessionTouchClick(session: session.id, kind: kind, element: id)
-        try session.sendInteraction(request, retryTimeout: retryTimeout)
+        try await session.sendInteraction(request, retryTimeout: retryTimeout)
     }
 
     /// Double clicks an element by id.
-    public func doubleClick(retryTimeout: TimeInterval? = nil) throws {
+    public func doubleClick(retryTimeout: TimeInterval? = nil) async throws {
         let request = Requests.SessionTouchDoubleClick(session: session.id, element: id)
-        try session.sendInteraction(request, retryTimeout: retryTimeout)
+        try await session.sendInteraction(request, retryTimeout: retryTimeout)
     }
 
     /// - Parameters:
@@ -85,46 +99,57 @@ public struct Element {
     ///   - xOffset: The x offset in pixels to flick by.
     ///   - yOffset: The y offset in pixels to flick by.
     ///   - speed: The speed in pixels per seconds.
-    public func flick(xOffset: Double, yOffset: Double, speed: Double, retryTimeout: TimeInterval? = nil) throws {
-        let request = Requests.SessionTouchFlickElement(session: session.id, element: id, xOffset: xOffset, yOffset: yOffset, speed: speed)
-        try session.sendInteraction(request, retryTimeout: retryTimeout)
+    public func flick(
+        xOffset: Double, yOffset: Double, speed: Double, retryTimeout: TimeInterval? = nil
+    ) async throws {
+        let request = Requests.SessionTouchFlickElement(
+            session: session.id, element: id, xOffset: xOffset, yOffset: yOffset, speed: speed)
+        try await session.sendInteraction(request, retryTimeout: retryTimeout)
     }
 
     /// Search for an element using a given locator, starting from this element.
     /// - Parameter locator: The locator strategy to use.
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
-    @discardableResult // for use as an assertion
-    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws -> Element {
-        try session.findElement(startingAt: self, locator: locator, waitTimeout: waitTimeout)
+    @discardableResult  // for use as an assertion
+    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) async throws
+        -> Element
+    {
+        try await session.findElement(startingAt: self, locator: locator, waitTimeout: waitTimeout)
     }
 
     /// Search for elements using a given locator, starting from this element.
     /// - Parameter using: The locator strategy to use.
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, or an empty array.
-    public func findElements(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws -> [Element] {
-        try session.findElements(startingAt: self, locator: locator, waitTimeout: waitTimeout)
+    public func findElements(locator: ElementLocator, waitTimeout: TimeInterval? = nil) async throws
+        -> [Element]
+    {
+        try await session.findElements(startingAt: self, locator: locator, waitTimeout: waitTimeout)
     }
 
     /// Gets an attribute of this element.
     /// - Parameter name: the attribute name.
     /// - Returns: the attribute value string.
-    public func getAttribute(name: String) throws -> String {
-        try webDriver.send(Requests.ElementAttribute(
-            session: session.id, element: id, attribute: name)).value
+    public func getAttribute(name: String) async throws -> String {
+        try await webDriver.send(
+            Requests.ElementAttribute(
+                session: session.id, element: id, attribute: name)
+        ).value
     }
 
     /// Sends key presses to this element.
     /// - Parameter keys: A key sequence according to the WebDriver spec.
-    public func sendKeys(_ keys: Keys) throws {
-        try webDriver.send(Requests.ElementValue(
-            session: session.id, element: id, text: keys.rawValue))
+    public func sendKeys(_ keys: Keys) async throws {
+        try await webDriver.send(
+            Requests.ElementValue(
+                session: session.id, element: id, text: keys.rawValue))
     }
 
     /// Clears the text of an editable element.
-    public func clear() throws {
-        try webDriver.send(Requests.ElementClear(
-            session: session.id, element: id))
+    public func clear() async throws {
+        try await webDriver.send(
+            Requests.ElementClear(
+                session: session.id, element: id))
     }
 }

--- a/Sources/WebDriver/Element.swift
+++ b/Sources/WebDriver/Element.swift
@@ -119,7 +119,7 @@ public struct Element {
     /// - Parameter keys: A key sequence according to the WebDriver spec.
     public func sendKeys(_ keys: Keys) throws {
         try webDriver.send(Requests.ElementValue(
-            session: session.id, element: id, value: [keys.rawValue]))
+            session: session.id, element: id, text: keys.rawValue))
     }
 
     /// Clears the text of an editable element.

--- a/Sources/WebDriver/ErrorResponse.swift
+++ b/Sources/WebDriver/ErrorResponse.swift
@@ -1,10 +1,10 @@
 /// A response received when an error occurs when processing a request.
 public struct ErrorResponse: Codable, Error, CustomStringConvertible {
-    public var status: Status
+    public var status: Status?
     public var value: Value
 
     public var description: String {
-        var str = "Error \(status.rawValue)"
+        var str = "Error \(status?.rawValue ?? -1)"
         if let error = value.error {
             str += " (\(error))"
         }

--- a/Sources/WebDriver/HTTPWebDriver.swift
+++ b/Sources/WebDriver/HTTPWebDriver.swift
@@ -1,6 +1,7 @@
 import Foundation
+
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+    import FoundationNetworking
 #endif
 
 /// Thrown if we fail to detect the protocol a webdriver server uses.
@@ -11,31 +12,36 @@ public struct HTTPWebDriver: WebDriver {
     private let serverURL: URL
     public let wireProtocol: WireProtocol
 
-    public static let defaultRequestTimeout: TimeInterval = 5 // seconds
+    public static let defaultRequestTimeout: TimeInterval = 5  // seconds
 
     public init(endpoint: URL, wireProtocol: WireProtocol) {
         serverURL = endpoint
         self.wireProtocol = wireProtocol
     }
 
-    public static func createWithDetectedProtocol(serverURL: URL) throws -> HTTPWebDriver {
-        .init(endpoint: serverURL, wireProtocol: try detectProtocol(serverURL: serverURL))
+    public static func createWithDetectedProtocol(serverURL: URL) async throws -> HTTPWebDriver {
+        .init(endpoint: serverURL, wireProtocol: try await detectProtocol(serverURL: serverURL))
     }
 
-    public static func detectProtocol(serverURL: URL) throws -> WireProtocol {
+    public static func detectProtocol(serverURL: URL) async throws -> WireProtocol {
         // The status request is the same for the Selenium Legacy JSON protocol and W3C,
         // but the response format is different.
-        let urlRequest = try Self.buildURLRequest(serverURL: serverURL, Requests.LegacySelenium.Status())
+        let urlRequest = try Self.buildURLRequest(
+            serverURL: serverURL, Requests.LegacySelenium.Status())
 
         // Send the request and decode result or error
-        let (status, responseData) = try urlRequest.send()
+        let (status, responseData) = try await urlRequest.send()
         guard status == 200 else {
             throw try JSONDecoder().decode(ErrorResponse.self, from: responseData)
         }
 
-        if let _ = try? JSONDecoder().decode(Requests.LegacySelenium.Status.Response.self, from: responseData) {
+        if (try? JSONDecoder().decode(
+            Requests.LegacySelenium.Status.Response.self, from: responseData)) != nil
+        {
             return .legacySelenium
-        } else if let _ = try? JSONDecoder().decode(Requests.W3C.Status.Response.self, from: responseData) {
+        } else if (try? JSONDecoder().decode(Requests.W3C.Status.Response.self, from: responseData))
+            != nil
+        {
             return .w3c
         } else {
             throw ProtocolDetectionError()
@@ -43,11 +49,11 @@ public struct HTTPWebDriver: WebDriver {
     }
 
     @discardableResult
-    public func send<Req: Request>(_ request: Req) throws -> Req.Response {
+    public func send<Req: Request>(_ request: Req) async throws -> Req.Response {
         let urlRequest = try Self.buildURLRequest(serverURL: self.serverURL, request)
 
         // Send the request and decode result or error
-        let (status, responseData) = try urlRequest.send()
+        let (status, responseData) = try await urlRequest.send()
         guard status == 200 else {
             throw try JSONDecoder().decode(ErrorResponse.self, from: responseData)
         }
@@ -55,7 +61,9 @@ public struct HTTPWebDriver: WebDriver {
         return try JSONDecoder().decode(Req.Response.self, from: responseData)
     }
 
-    private static func buildURLRequest<Req: Request>(serverURL: URL, _ request: Req) throws -> URLRequest {
+    private static func buildURLRequest<Req: Request>(serverURL: URL, _ request: Req) throws
+        -> URLRequest
+    {
         var url = serverURL
         for (index, pathComponent) in request.pathComponents.enumerated() {
             let last = index == request.pathComponents.count - 1
@@ -69,7 +77,8 @@ public struct HTTPWebDriver: WebDriver {
 
         // Add the body if the Request type defines one
         if Req.Body.self != CodableNone.self {
-            urlRequest.addValue("application/json;charset=UTF-8", forHTTPHeaderField: "content-type")
+            urlRequest.addValue(
+                "application/json;charset=UTF-8", forHTTPHeaderField: "content-type")
             urlRequest.httpBody = try JSONEncoder().encode(request.body)
         }
 

--- a/Sources/WebDriver/Poll.swift
+++ b/Sources/WebDriver/Poll.swift
@@ -1,31 +1,36 @@
-import class Foundation.Thread
-import struct Foundation.TimeInterval
 import struct Dispatch.DispatchTime
+import struct Foundation.TimeInterval
 
 /// Calls a closure repeatedly with exponential backoff until it reports success or a timeout elapses.
 /// Thrown errors bubble up immediately, returned errors allow retries.
 /// - Returns: The successful value.
 internal func poll<Value>(
-        timeout: TimeInterval,
-        initialPeriod: TimeInterval = 0.001,
-        work: () throws -> Result<Value, Error>) throws -> Value {
+    timeout: TimeInterval,
+    initialPeriod: TimeInterval = 0.001,
+    work: () async throws -> Result<Value, Error>
+) async throws -> Value {
     let startTime = DispatchTime.now()
-    var lastResult = try work()
+    var lastResult = try await work()
     var period = initialPeriod
     while true {
         guard case .failure = lastResult else { break }
 
         // Check if we ran out of time and return the last result
-        let elapsedTime = Double(DispatchTime.now().uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000_000
+        let elapsedTime =
+            Double(DispatchTime.now().uptimeNanoseconds - startTime.uptimeNanoseconds)
+            / 1_000_000_000
         let remainingTime = timeout - elapsedTime
         if remainingTime < 0 { break }
 
         // Sleep for the next period and retry
         let sleepTime = min(period, remainingTime)
-        Thread.sleep(forTimeInterval: sleepTime)
+        if sleepTime > 0 {
+            let nanoseconds = UInt64(sleepTime * 1_000_000_000)
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
 
-        lastResult = try work()
-        period *= 2 // Exponential backoff
+        lastResult = try await work()
+        period *= 2  // Exponential backoff
     }
 
     return try lastResult.get()
@@ -34,13 +39,14 @@ internal func poll<Value>(
 /// Calls a closure repeatedly with exponential backoff until it reports success or a timeout elapses.
 /// - Returns: Whether the closure reported success within the expected time.
 internal func poll(
-        timeout: TimeInterval,
-        initialPeriod: TimeInterval = 0.001,
-        work: () throws -> Bool) throws -> Bool {
+    timeout: TimeInterval,
+    initialPeriod: TimeInterval = 0.001,
+    work: () async throws -> Bool
+) async throws -> Bool {
     struct FalseError: Error {}
     do {
-        try poll(timeout: timeout, initialPeriod: initialPeriod) {
-            try work() ? .success(()) : .failure(FalseError())
+        try await poll(timeout: timeout, initialPeriod: initialPeriod) {
+            try await work() ? .success(()) : .failure(FalseError())
         }
         return true
     } catch _ as FalseError {

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -675,20 +675,21 @@ public enum Requests {
         public var method: HTTPMethod { .post }
     }
 
-    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidwindow_handle
+    // https://www.w3.org/TR/webdriver/#get-window-handle
     public struct SessionWindowHandle: Request {
         public var session: String 
 
-        public var pathComponents: [String] { ["session", session, "window_handle"] }
+        public var pathComponents: [String] { ["session", session, "window"] }
         public var method: HTTPMethod { .get }
 
         public typealias Response = ResponseWithValue<String>
     }
 
+    // https://www.w3.org/TR/webdriver/#get-window-handles
     public struct SessionWindowHandles: Request {
         public var session: String 
 
-        public var pathComponents: [String] { ["session", session, "window_handles"] }
+        public var pathComponents: [String] { ["session", session, "window", "handles"] }
         public var method: HTTPMethod { .get }
 
         public typealias Response = ResponseWithValue<Array<String>>

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -357,16 +357,18 @@ public enum Requests {
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtimeouts
     public struct SessionTimeouts: Request {
         public var session: String
-        public var type: TimeoutType
-        public var ms: Double
+        public var script: Double?
+        public var pageLoad: Double?
+        public var implicit: Double?
 
         public var pathComponents: [String] { ["session", session, "timeouts"] }
         public var method: HTTPMethod { .post }
-        public var body: Body { .init(type: type, ms: ms) }
+        public var body: Body { .init(script: script, pageLoad: pageLoad, implicit: implicit) }
 
         public struct Body: Codable {
-            public var type: TimeoutType
-            public var ms: Double
+            public var script: Double?
+            public var pageLoad: Double?
+            public var implicit: Double?
         }
     }
 

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -38,7 +38,9 @@ public enum Requests {
         public var element: String
         public var attribute: String
 
-        public var pathComponents: [String] { ["session", session, "element", element, "attribute", attribute] }
+        public var pathComponents: [String] {
+            ["session", session, "element", element, "attribute", attribute]
+        }
         public var method: HTTPMethod { .get }
 
         public typealias Response = ResponseWithValue<String>
@@ -67,7 +69,9 @@ public enum Requests {
         public var session: String
         public var element: String
 
-        public var pathComponents: [String] { ["session", session, "element", element, "displayed"] }
+        public var pathComponents: [String] {
+            ["session", session, "element", element, "displayed"]
+        }
         public var method: HTTPMethod { .get }
 
         // Override the whole Response struct instead of just ResponseValue
@@ -95,10 +99,12 @@ public enum Requests {
     public struct ElementSelected: Request {
         public var session: String
         public var element: String
-        
-        public var pathComponents: [String] { ["session", session, "element", element, "selected"] }
+
+        public var pathComponents: [String] {
+            ["session", session, "element", element, "selected"]
+        }
         public var method: HTTPMethod { .get }
-        
+
         public struct Response: Codable {
             public var value: Bool
         }
@@ -125,7 +131,9 @@ public enum Requests {
         public var session: String
         public var element: String
 
-        public var pathComponents: [String] { ["session", session, "element", element, "location"] }
+        public var pathComponents: [String] {
+            ["session", session, "element", element, "location"]
+        }
         public var method: HTTPMethod { .get }
 
         public typealias Response = ResponseWithValue<ResponseValue>
@@ -461,15 +469,17 @@ public enum Requests {
         }
     }
 
-    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidexecute
-    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidexecute_async
+    // https://www.w3.org/TR/webdriver/#execute-script
+    // https://www.w3.org/TR/webdriver/#execute-async-script
     public struct SessionScript: Request {
         public var session: String
         public var script: String
         public var args: [String]
         public var async: Bool
 
-        public var pathComponents: [String] { ["session", session, async ? "execute_async" : "execute"] }
+        public var pathComponents: [String] {
+            ["session", session, async ? "execute/async" : "execute/sync"]
+        }
         public var method: HTTPMethod { .post }
         public var body: Body { .init(script: script, args: args) }
         public struct Body: Codable {
@@ -477,7 +487,7 @@ public enum Requests {
             public var args: [String]
         }
     }
-    
+
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidwindow
     public enum SessionWindow {
         public struct Post: Request {
@@ -515,7 +525,9 @@ public enum Requests {
             public var width: Double
             public var height: Double
 
-            public var pathComponents: [String] { ["session", session, "window", windowHandle, "size"] }
+            public var pathComponents: [String] {
+                ["session", session, "window", windowHandle, "size"]
+            }
             public var method: HTTPMethod { .post }
             public var body: Body { .init(width: width, height: height) }
 
@@ -529,7 +541,9 @@ public enum Requests {
             public var session: String
             public var windowHandle: String
 
-            public var pathComponents: [String] { ["session", session, "window", windowHandle, "size"] }
+            public var pathComponents: [String] {
+                ["session", session, "window", windowHandle, "size"]
+            }
             public var method: HTTPMethod { .get }
 
             public typealias Response = ResponseWithValue<ResponseValue>
@@ -539,11 +553,11 @@ public enum Requests {
             }
         }
     }
-  
+
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchdoubleclick
     public struct SessionTouchDoubleClick: Request {
         public var session: String
-        public var element: String 
+        public var element: String
 
         public var pathComponents: [String] { ["session", session, "touch", "doubleclick"] }
         public var method: HTTPMethod { .post }
@@ -556,7 +570,7 @@ public enum Requests {
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchflick
     public struct SessionTouchFlickElement: Request {
-        public var session: String 
+        public var session: String
         public var element: String
         public var xOffset: Double
         public var yOffset: Double
@@ -581,14 +595,14 @@ public enum Requests {
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtouchflick-1
     public struct SessionTouchFlick: Request {
-        public var session: String 
+        public var session: String
         public var xSpeed: Double
         public var ySpeed: Double
-        
+
         public var pathComponents: [String] { ["session", session, "touch", "flick"] }
         public var method: HTTPMethod { .post }
         public var body: Body { .init(xSpeed: xSpeed, ySpeed: ySpeed) }
-        
+
         public struct Body: Codable {
             public var xSpeed: Double
             public var ySpeed: Double
@@ -613,9 +627,9 @@ public enum Requests {
 
         public struct Get: Request {
             public var session: String
-            
+
             public var pathComponents: [String] { ["session", session, "location"] }
-            public var method: HTTPMethod {.get}
+            public var method: HTTPMethod { .get }
 
             public typealias Response = ResponseWithValue<Location>
         }
@@ -623,7 +637,7 @@ public enum Requests {
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidsource
     public struct SessionSource: Request {
-        public var session: String 
+        public var session: String
 
         public var pathComponents: [String] { ["session", session, "source"] }
         public var method: HTTPMethod { .get }
@@ -631,7 +645,7 @@ public enum Requests {
         public typealias Response = ResponseWithValue<String>
     }
 
-     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidorientation
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidorientation
     public enum SessionOrientation {
         public struct Post: Request {
             public var session: String
@@ -662,9 +676,11 @@ public enum Requests {
             public var session: String
             public var windowHandle: String
             public var x: Double
-            public var y: Double 
+            public var y: Double
 
-            public var pathComponents: [String] { ["session", session, "window", windowHandle, "position"] }
+            public var pathComponents: [String] {
+                ["session", session, "window", windowHandle, "position"]
+            }
             public var method: HTTPMethod { .post }
             public var body: Body { .init(x: x, y: y) }
 
@@ -678,7 +694,9 @@ public enum Requests {
             public var session: String
             public var windowHandle: String
 
-            public var pathComponents: [String] { ["session", session, "window", windowHandle, "position"] }
+            public var pathComponents: [String] {
+                ["session", session, "window", windowHandle, "position"]
+            }
             public var method: HTTPMethod { .get }
 
             public typealias Response = ResponseWithValue<ResponseValue>
@@ -691,15 +709,17 @@ public enum Requests {
 
     public struct WindowMaximize: Request {
         public var session: String
-        public var windowHandle: String 
+        public var windowHandle: String
 
-        public var pathComponents: [String] { ["session", session, "window", windowHandle, "maximize"] }
+        public var pathComponents: [String] {
+            ["session", session, "window", windowHandle, "maximize"]
+        }
         public var method: HTTPMethod { .post }
     }
 
     // https://www.w3.org/TR/webdriver/#get-window-handle
     public struct SessionWindowHandle: Request {
-        public var session: String 
+        public var session: String
 
         public var pathComponents: [String] { ["session", session, "window"] }
         public var method: HTTPMethod { .get }
@@ -709,11 +729,11 @@ public enum Requests {
 
     // https://www.w3.org/TR/webdriver/#get-window-handles
     public struct SessionWindowHandles: Request {
-        public var session: String 
+        public var session: String
 
         public var pathComponents: [String] { ["session", session, "window", "handles"] }
         public var method: HTTPMethod { .get }
 
-        public typealias Response = ResponseWithValue<Array<String>>
+        public typealias Response = ResponseWithValue<[String]>
     }
 }

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -306,6 +306,28 @@ public enum Requests {
         }
     }
 
+    // https://www.w3.org/TR/webdriver/#set-window-rect
+    public struct SessionWindowRect: Request {
+        public var session: String
+        public var x: Int?
+        public var y: Int?
+        public var width: Int?
+        public var height: Int?
+
+        public var pathComponents: [String] { ["session", session, "window", "rect"] }
+        public var method: HTTPMethod { .post }
+        public var body: Body { .init(x: x, y: y, width: width, height: height) }
+
+        public struct Body: Codable {
+            public var x: Int?
+            public var y: Int?
+            public var width: Int?
+            public var height: Int?
+        }
+
+        public typealias Response = ResponseWithValue<Body>
+    }
+
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidrefresh
     public struct SessionRefresh: Request {
         public var session: String

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -473,7 +473,7 @@ public enum Requests {
 
     // https://www.w3.org/TR/webdriver/#execute-script
     // https://www.w3.org/TR/webdriver/#execute-async-script
-    public struct SessionScript: Request {
+    public struct SessionScript<Result: Codable>: Request {
         public var session: String
         public var script: String
         public var args: [String]
@@ -488,6 +488,8 @@ public enum Requests {
             public var script: String
             public var args: [String]
         }
+
+        public typealias Response = ResponseWithValue<Result>
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidwindow

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -28,7 +28,7 @@ public enum Requests {
         public var element: String
 
         enum CodingKeys: String, CodingKey {
-            case element = "ELEMENT"
+            case element = "element-6066-11e4-a52e-4f735466cecf"
         }
     }
 

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -110,19 +110,19 @@ public enum Requests {
         }
     }
 
-    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidvalue
+    // https://www.w3.org/TR/webdriver/#element-send-keys
     public struct ElementValue: Request {
         public var session: String
         public var element: String
-        public var value: [String]
+        public var text: String
 
         public var pathComponents: [String] { ["session", session, "element", element, "value"] }
 
         public var method: HTTPMethod { .post }
-        public var body: Body { .init(value: value) }
+        public var body: Body { .init(text: text) }
 
         public struct Body: Codable {
-            public var value: [String]
+            public var text: String
         }
     }
 

--- a/Sources/WebDriver/Requests.swift
+++ b/Sources/WebDriver/Requests.swift
@@ -1,5 +1,9 @@
 /// Defines request and response types for the WebDriver protocol.
 public enum Requests {
+    public struct EmptyBody: Codable {
+        public init() {}
+    }
+
     public struct ResponseWithValue<Value>: Codable where Value: Codable {
         public var value: Value
 
@@ -53,6 +57,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "element", element, "clear"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementidclick
@@ -62,6 +68,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "element", element, "click"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelementiddisplayed
@@ -185,6 +193,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "back"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidbuttondown
@@ -224,6 +234,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "doubleclick"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidelement
@@ -274,6 +286,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "forward"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidkeys
@@ -342,6 +356,8 @@ public enum Requests {
 
         public var pathComponents: [String] { ["session", session, "refresh"] }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidscreenshot
@@ -719,6 +735,8 @@ public enum Requests {
             ["session", session, "window", windowHandle, "maximize"]
         }
         public var method: HTTPMethod { .post }
+        public typealias Body = EmptyBody
+        public var body: Body { .init() }
     }
 
     // https://www.w3.org/TR/webdriver/#get-window-handle

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -268,6 +268,20 @@ public final class Session {
             session: id, element: element?.id, xOffset: xOffset, yOffset: yOffset))
     }
 
+    /// Alters the size and the position of the operating system window corresponding to
+    /// session's current top-level browsing context. If x and y are both present, the
+    /// window is moved to that location. If width and height are both present, the window
+    /// (including all external chrome) is resized as close as possible to those dimensions
+    /// (though not larger than the screen, smaller than the smallest possible window size, etc...).
+    /// - Parameter x: the screenX attribute of the window object
+    /// - Parameter y: the screenY attribute of the window object
+    /// - Parameter width: the width of the outer dimensions of the top-level browsing context
+    /// - Parameter height: the height of the outer dimensions of the top-level browsing context
+    public func setWindowRect(x: Int?, y: Int?, width: Int?, height: Int?) throws {
+        try webDriver.send(Requests.SessionWindowRect(
+            session: id, x: x, y: y, width: width, height: height))
+    }
+
     /// Presses down one of the mouse buttons.
     /// - Parameter button: The button to be pressed.
     public func buttonDown(button: MouseButton = .left) throws {

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -18,7 +18,7 @@ public final class Session {
         self.id = existingId
         self.capabilities = capabilities
         if let implicitWaitTimeoutInMilliseconds = capabilities.timeouts?.implicit {
-            self.implicitWaitTimeout = Double(implicitWaitTimeoutInMilliseconds) / 1000.0
+            self._implicitWaitTimeout = Double(implicitWaitTimeoutInMilliseconds) / 1000.0
         }
         self.shouldDelete = owned
     }
@@ -27,8 +27,8 @@ public final class Session {
     fileprivate convenience init(
         webDriver: any WebDriver, desiredCapabilities: Capabilities,
         requiredCapabilities: Capabilities?
-    ) throws {
-        let response = try webDriver.send(
+    ) async throws {
+        let response = try await webDriver.send(
             Requests.LegacySelenium.Session(
                 desiredCapabilities: desiredCapabilities, requiredCapabilities: requiredCapabilities
             ))
@@ -42,8 +42,8 @@ public final class Session {
     /// Initializer for W3C Protocol
     fileprivate convenience init(
         webDriver: any WebDriver, alwaysMatch: Capabilities, firstMatch: [Capabilities]
-    ) throws {
-        let response = try webDriver.send(
+    ) async throws {
+        let response = try await webDriver.send(
             Requests.W3C.Session(
                 alwaysMatch: alwaysMatch, firstMatch: firstMatch))
         self.init(
@@ -53,14 +53,14 @@ public final class Session {
             owned: true)
     }
 
-    public convenience init(webDriver: any WebDriver, capabilities: Capabilities) throws {
+    public convenience init(webDriver: any WebDriver, capabilities: Capabilities) async throws {
         switch webDriver.wireProtocol {
         case .legacySelenium:
-            try self.init(
+            try await self.init(
                 webDriver: webDriver, desiredCapabilities: capabilities,
                 requiredCapabilities: capabilities)
         case .w3c:
-            try self.init(webDriver: webDriver, alwaysMatch: capabilities, firstMatch: [])
+            try await self.init(webDriver: webDriver, alwaysMatch: capabilities, firstMatch: [])
         }
     }
 
@@ -68,8 +68,8 @@ public final class Session {
         public static func create(
             webDriver: any WebDriver, desiredCapabilities: Capabilities,
             requiredCapabilities: Capabilities? = nil
-        ) throws -> Session {
-            try Session(
+        ) async throws -> Session {
+            try await Session(
                 webDriver: webDriver, desiredCapabilities: desiredCapabilities,
                 requiredCapabilities: requiredCapabilities)
         }
@@ -78,26 +78,26 @@ public final class Session {
     public enum W3C {
         public static func create(
             webDriver: any WebDriver, alwaysMatch: Capabilities, firstMatch: [Capabilities] = []
-        ) throws -> Session {
-            try Session(webDriver: webDriver, alwaysMatch: alwaysMatch, firstMatch: firstMatch)
+        ) async throws -> Session {
+            try await Session(
+                webDriver: webDriver, alwaysMatch: alwaysMatch, firstMatch: firstMatch)
         }
     }
 
     /// The amount of time the driver should implicitly wait when searching for elements.
     /// This functionality is either implemented by the driver, or emulated by swift-webdriver as a fallback.
-    public var implicitWaitTimeout: TimeInterval {
-        get { _implicitWaitTimeout }
-        set {
-            if newValue == _implicitWaitTimeout { return }
-            if !emulateImplicitWait {
-                do {
-                    try setTimeout(implicit: newValue)
-                } catch {
-                    emulateImplicitWait = true
-                }
+    public var implicitWaitTimeout: TimeInterval { _implicitWaitTimeout }
+
+    public func setImplicitWaitTimeout(_ newValue: TimeInterval) async throws {
+        if newValue == _implicitWaitTimeout { return }
+        if !emulateImplicitWait {
+            do {
+                try await setTimeout(implicit: newValue)
+            } catch {
+                emulateImplicitWait = true
             }
-            _implicitWaitTimeout = newValue
         }
+        _implicitWaitTimeout = newValue
     }
 
     /// The amount of time interactions should be retried before failing.
@@ -106,17 +106,17 @@ public final class Session {
 
     /// The title of this session such as the tab or window text.
     public var title: String {
-        get throws {
-            try webDriver.send(Requests.SessionTitle(session: id)).value
+        get async throws {
+            try await webDriver.send(Requests.SessionTitle(session: id)).value
         }
     }
 
     /// The current URL of this session.
     public var url: URL {
-        get throws {
+        get async throws {
             guard
                 let result = URL(
-                    string: try webDriver.send(Requests.SessionUrl.Get(session: id)).value)
+                    string: try await webDriver.send(Requests.SessionUrl.Get(session: id)).value)
             else {
                 throw DecodingError.dataCorrupted(
                     DecodingError.Context(
@@ -130,15 +130,15 @@ public final class Session {
     /// Navigates to a given URL.
     /// This is logically a setter for the 'url' property,
     /// but Swift doesn't support throwing setters.
-    public func url(_ url: URL) throws {
-        try webDriver.send(Requests.SessionUrl.Post(session: id, url: url.absoluteString))
+    public func url(_ url: URL) async throws {
+        try await webDriver.send(Requests.SessionUrl.Post(session: id, url: url.absoluteString))
     }
 
     /// The active (focused) element.
     public var activeElement: Element? {
-        get throws {
+        get async throws {
             do {
-                let response = try webDriver.send(Requests.SessionActiveElement(session: id))
+                let response = try await webDriver.send(Requests.SessionActiveElement(session: id))
                 return Element(session: self, id: response.value.element)
             } catch let error as ErrorResponse where error.status == .noSuchElement {
                 return nil
@@ -147,15 +147,15 @@ public final class Session {
     }
 
     public var location: Location {
-        get throws {
-            let response = try webDriver.send(Requests.SessionLocation.Get(session: id))
+        get async throws {
+            let response = try await webDriver.send(Requests.SessionLocation.Get(session: id))
             return response.value
         }
     }
 
     public var orientation: ScreenOrientation {
-        get throws {
-            let response = try webDriver.send(Requests.SessionOrientation.Get(session: id))
+        get async throws {
+            let response = try await webDriver.send(Requests.SessionOrientation.Get(session: id))
             return response.value
         }
     }
@@ -166,9 +166,9 @@ public final class Session {
         pageLoad: TimeInterval? = nil,
         implicit: TimeInterval? = nil
     )
-        throws
+        async throws
     {
-        try webDriver.send(
+        try await webDriver.send(
             Requests.SessionTimeouts(
                 session: id,
                 script: script != nil ? script! * 1000 : nil,
@@ -179,27 +179,27 @@ public final class Session {
         if let i = implicit { _implicitWaitTimeout = i }
     }
 
-    public func execute(script: String, args: [String] = [], async: Bool = false) throws {
-        try webDriver.send(
+    public func execute(script: String, args: [String] = [], async: Bool = false) async throws {
+        try await webDriver.send(
             Requests.SessionScript(session: id, script: script, args: args, async: async))
     }
 
-    public func back() throws {
-        try webDriver.send(Requests.SessionBack(session: id))
+    public func back() async throws {
+        try await webDriver.send(Requests.SessionBack(session: id))
     }
 
-    public func forward() throws {
-        try webDriver.send(Requests.SessionForward(session: id))
+    public func forward() async throws {
+        try await webDriver.send(Requests.SessionForward(session: id))
     }
 
-    public func refresh() throws {
-        try webDriver.send(Requests.SessionRefresh(session: id))
+    public func refresh() async throws {
+        try await webDriver.send(Requests.SessionRefresh(session: id))
     }
 
     /// Takes a screenshot of the current page.
     /// - Returns: The screenshot data as a PNG file.
-    public func screenshot() throws -> Data {
-        let base64: String = try webDriver.send(
+    public func screenshot() async throws -> Data {
+        let base64: String = try await webDriver.send(
             Requests.SessionScreenshot(session: id)
         ).value
         guard let data = Data(base64Encoded: base64) else {
@@ -216,54 +216,60 @@ public final class Session {
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The element that was found, if any.
     @discardableResult  // for use as an assertion
-    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws
+    public func findElement(locator: ElementLocator, waitTimeout: TimeInterval? = nil) async throws
         -> Element
     {
-        try findElement(startingAt: nil, locator: locator, waitTimeout: waitTimeout)
+        try await findElement(startingAt: nil, locator: locator, waitTimeout: waitTimeout)
     }
 
     /// Finds elements by id, starting from the root.
     /// - Parameter locator: The locator strategy to use.
     /// - Parameter waitTimeout: The amount of time to wait for element existence. Overrides the implicit wait timeout.
     /// - Returns: The elements that were found, or an empty array.
-    public func findElements(locator: ElementLocator, waitTimeout: TimeInterval? = nil) throws
+    public func findElements(locator: ElementLocator, waitTimeout: TimeInterval? = nil) async throws
         -> [Element]
     {
-        try findElements(startingAt: nil, locator: locator, waitTimeout: waitTimeout)
+        try await findElements(startingAt: nil, locator: locator, waitTimeout: waitTimeout)
     }
 
     /// Overrides the implicit wait timeout during a block of code.
     private func withImplicitWaitTimeout<Result>(
-        _ value: TimeInterval?, _ block: () throws -> Result
-    ) rethrows -> Result {
+        _ value: TimeInterval?, _ block: () async throws -> Result
+    ) async throws -> Result {
         if let value, value != _implicitWaitTimeout {
             let previousValue = _implicitWaitTimeout
-            implicitWaitTimeout = value
-            defer { implicitWaitTimeout = previousValue }
-            return try block()
+            try await setImplicitWaitTimeout(value)
+            do {
+                let result = try await block()
+                try await setImplicitWaitTimeout(previousValue)
+                return result
+            } catch {
+                try await setImplicitWaitTimeout(previousValue)
+                throw error
+            }
         } else {
-            return try block()
+            return try await block()
         }
     }
 
     /// Common logic for `Session.findElement` and `Element.findElement`.
     internal func findElement(
         startingAt subtreeRoot: Element?, locator: ElementLocator, waitTimeout: TimeInterval?
-    ) throws -> Element {
+    ) async throws -> Element {
         precondition(subtreeRoot == nil || subtreeRoot?.session === self)
 
-        return try withImplicitWaitTimeout(waitTimeout) {
+        return try await withImplicitWaitTimeout(waitTimeout) {
             let request = Requests.SessionElement(
                 session: id, element: subtreeRoot?.id, locator: locator)
 
             do {
-                return try poll(
+                return try await poll(
                     timeout: emulateImplicitWait
                         ? (waitTimeout ?? _implicitWaitTimeout) : TimeInterval.zero
                 ) {
                     do {
                         // Allow errors to bubble up unless they are specifically saying that the element was not found.
-                        let elementId = try webDriver.send(request).value.element
+                        let elementId = try await webDriver.send(request).value.element
                         return .success(Element(session: self, id: elementId))
                     } catch let error as ErrorResponse where error.status == .noSuchElement {
                         // Return instead of throwing to indicate that `poll` can retry as needed.
@@ -279,20 +285,20 @@ public final class Session {
     /// Common logic for `Session.findElements` and `Element.findElements`.
     internal func findElements(
         startingAt element: Element?, locator: ElementLocator, waitTimeout: TimeInterval?
-    ) throws -> [Element] {
-        try withImplicitWaitTimeout(waitTimeout) {
+    ) async throws -> [Element] {
+        try await withImplicitWaitTimeout(waitTimeout) {
             let request = Requests.SessionElements(
                 session: id, element: element?.id, locator: locator)
 
             do {
-                return try poll(
+                return try await poll(
                     timeout: emulateImplicitWait
                         ? (waitTimeout ?? _implicitWaitTimeout) : TimeInterval.zero
                 ) {
                     do {
                         // Allow errors to bubble up unless they are specifically saying that the element was not found.
                         return .success(
-                            try webDriver.send(request).value.map {
+                            try await webDriver.send(request).value.map {
                                 Element(session: self, id: $0.element)
                             })
                     } catch let error as ErrorResponse where error.status == .noSuchElement {
@@ -311,17 +317,18 @@ public final class Session {
     ///   - waitTimeout: Optional value to override defaultRetryTimeout.
     ///   - xSpeed: The x speed in pixels per second.
     ///   - ySpeed: The y speed in pixels per second.
-    public func flick(xSpeed: Double, ySpeed: Double) throws {
-        try webDriver.send(Requests.SessionTouchFlick(session: id, xSpeed: xSpeed, ySpeed: ySpeed))
+    public func flick(xSpeed: Double, ySpeed: Double) async throws {
+        let request = Requests.SessionTouchFlick(session: id, xSpeed: xSpeed, ySpeed: ySpeed)
+        try await sendInteraction(request)
     }
 
     /// Moves the pointer to a location relative to the current pointer position or an element.
     /// - Parameter element: if not nil the top left of the element provides the origin.
     /// - Parameter xOffset: x offset from the left of the element.
     /// - Parameter yOffset: y offset from the top of the element.
-    public func moveTo(element: Element? = nil, xOffset: Int = 0, yOffset: Int = 0) throws {
+    public func moveTo(element: Element? = nil, xOffset: Int = 0, yOffset: Int = 0) async throws {
         precondition(element?.session == nil || element?.session === self)
-        try webDriver.send(
+        try await webDriver.send(
             Requests.SessionMoveTo(
                 session: id, element: element?.id, xOffset: xOffset, yOffset: yOffset))
     }
@@ -335,63 +342,63 @@ public final class Session {
     /// - Parameter y: the screenY attribute of the window object
     /// - Parameter width: the width of the outer dimensions of the top-level browsing context
     /// - Parameter height: the height of the outer dimensions of the top-level browsing context
-    public func setWindowRect(x: Int?, y: Int?, width: Int?, height: Int?) throws {
-        try webDriver.send(
+    public func setWindowRect(x: Int?, y: Int?, width: Int?, height: Int?) async throws {
+        try await webDriver.send(
             Requests.SessionWindowRect(
                 session: id, x: x, y: y, width: width, height: height))
     }
 
     /// Presses down one of the mouse buttons.
     /// - Parameter button: The button to be pressed.
-    public func buttonDown(button: MouseButton = .left) throws {
-        try webDriver.send(
+    public func buttonDown(button: MouseButton = .left) async throws {
+        try await webDriver.send(
             Requests.SessionButton(
                 session: id, action: .buttonDown, button: button))
     }
 
     /// Releases one of the mouse buttons.
     /// - Parameter button: The button to be released.
-    public func buttonUp(button: MouseButton = .left) throws {
-        try webDriver.send(
+    public func buttonUp(button: MouseButton = .left) async throws {
+        try await webDriver.send(
             Requests.SessionButton(
                 session: id, action: .buttonUp, button: button))
     }
 
     /// Clicks one of the mouse buttons.
     /// - Parameter button: The button to be clicked.
-    public func click(button: MouseButton = .left) throws {
-        try webDriver.send(
+    public func click(button: MouseButton = .left) async throws {
+        try await webDriver.send(
             Requests.SessionButton(
                 session: id, action: .click, button: button))
     }
 
     /// Double clicks the mouse at the current location.
-    public func doubleClick() throws {
-        try webDriver.send(Requests.SessionDoubleClick(session: id))
+    public func doubleClick() async throws {
+        try await webDriver.send(Requests.SessionDoubleClick(session: id))
     }
 
     /// Starts a touch point at a coordinate in this session.
-    public func touchDown(x: Int, y: Int) throws {
-        try webDriver.send(Requests.SessionTouchAt(session: id, action: .down, x: x, y: y))
+    public func touchDown(x: Int, y: Int) async throws {
+        try await webDriver.send(Requests.SessionTouchAt(session: id, action: .down, x: x, y: y))
     }
 
     /// Releases a touch point at a coordinate in this session.
-    public func touchUp(x: Int, y: Int) throws {
-        try webDriver.send(Requests.SessionTouchAt(session: id, action: .up, x: x, y: y))
+    public func touchUp(x: Int, y: Int) async throws {
+        try await webDriver.send(Requests.SessionTouchAt(session: id, action: .up, x: x, y: y))
     }
 
     /// Moves a touch point at a coordinate in this session.
-    public func touchMove(x: Int, y: Int) throws {
-        try webDriver.send(Requests.SessionTouchAt(session: id, action: .move, x: x, y: y))
+    public func touchMove(x: Int, y: Int) async throws {
+        try await webDriver.send(Requests.SessionTouchAt(session: id, action: .move, x: x, y: y))
     }
 
     /// Scrolls via touch.
     /// - Parameter element: The element providing the screen location where the scroll starts.
     /// - Parameter xOffset: The x offset to scroll by, in pixels.
     /// - Parameter yOffset: The y offset to scroll by, in pixels.
-    public func touchScroll(element: Element? = nil, xOffset: Int, yOffset: Int) throws {
+    public func touchScroll(element: Element? = nil, xOffset: Int, yOffset: Int) async throws {
         precondition(element?.session == nil || element?.session === self)
-        try webDriver.send(
+        try await webDriver.send(
             Requests.SessionTouchScroll(
                 session: id, element: element?.id, xOffset: xOffset, yOffset: yOffset))
     }
@@ -399,78 +406,79 @@ public final class Session {
     /// Sends key presses to this session.
     /// - Parameter keys: A key sequence according to the WebDriver spec.
     /// - Parameter releaseModifiers: A boolean indicating whether to release modifier keys at the end of the sequence.
-    public func sendKeys(_ keys: Keys, releaseModifiers: Bool = true) throws {
+    public func sendKeys(_ keys: Keys, releaseModifiers: Bool = true) async throws {
         let value =
             releaseModifiers ? [keys.rawValue, Keys.releaseModifiers.rawValue] : [keys.rawValue]
-        try webDriver.send(Requests.SessionKeys(session: id, value: value))
+        try await webDriver.send(Requests.SessionKeys(session: id, value: value))
     }
 
     /// Change focus to another window.
     /// - Parameter name: The window to change focus to.
-    public func focus(window name: String) throws {
-        try webDriver.send(Requests.SessionWindow.Post(session: id, name: name))
+    public func focus(window name: String) async throws {
+        try await webDriver.send(Requests.SessionWindow.Post(session: id, name: name))
     }
 
     /// Close selected window.
     /// - Parameter name: The selected window to close.
-    public func close(window name: String) throws {
-        try webDriver.send(Requests.SessionWindow.Delete(session: id, name: name))
+    public func close(window name: String) async throws {
+        try await webDriver.send(Requests.SessionWindow.Delete(session: id, name: name))
     }
 
     public func window(handle: String) throws -> Window { .init(session: self, handle: handle) }
 
     /// - Parameter: Orientation the window will flip to {LANDSCAPE|PORTRAIT}.
-    public func setOrientation(_ value: ScreenOrientation) throws {
-        try webDriver.send(Requests.SessionOrientation.Post(session: id, orientation: value))
+    public func setOrientation(_ value: ScreenOrientation) async throws {
+        try await webDriver.send(Requests.SessionOrientation.Post(session: id, orientation: value))
     }
 
     /// Get the current page source.
     public var source: String {
-        get throws {
-            try webDriver.send(Requests.SessionSource(session: id)).value
+        get async throws {
+            try await webDriver.send(Requests.SessionSource(session: id)).value
         }
     }
 
     /// - Returns: Current window handle.
     public var windowHandle: String {
-        get throws {
-            let response = try webDriver.send(Requests.SessionWindowHandle(session: id))
+        get async throws {
+            let response = try await webDriver.send(Requests.SessionWindowHandle(session: id))
             return response.value
         }
     }
 
     /// Set the current geolocation.
-    public func setLocation(_ location: Location) throws {
-        try webDriver.send(Requests.SessionLocation.Post(session: id, location: location))
+    public func setLocation(_ location: Location) async throws {
+        try await webDriver.send(Requests.SessionLocation.Post(session: id, location: location))
     }
 
-    public func setLocation(latitude: Double, longitude: Double, altitude: Double) throws {
-        try setLocation(Location(latitude: latitude, longitude: longitude, altitude: altitude))
+    public func setLocation(latitude: Double, longitude: Double, altitude: Double) async throws {
+        try await setLocation(
+            Location(latitude: latitude, longitude: longitude, altitude: altitude))
     }
 
     /// - Returns: Array of window handles.
     public var windowHandles: [String] {
-        get throws {
-            let response = try webDriver.send(Requests.SessionWindowHandles(session: id))
+        get async throws {
+            let response = try await webDriver.send(Requests.SessionWindowHandles(session: id))
             return response.value
         }
     }
 
     /// Deletes the current session.
-    public func delete() throws {
+    public func delete() async throws {
         guard shouldDelete else { return }
-        try webDriver.send(Requests.SessionDelete(session: id))
+        try await webDriver.send(Requests.SessionDelete(session: id))
         shouldDelete = false
     }
 
     /// Sends an interaction request, retrying until it is conclusive or the timeout elapses.
     internal func sendInteraction<Req: Request>(_ request: Req, retryTimeout: TimeInterval? = nil)
-        throws where Req.Response == CodableNone
+        async throws where Req.Response == CodableNone
     {
-        try poll(timeout: retryTimeout ?? implicitInteractionRetryTimeout) {
+        try await poll(timeout: retryTimeout ?? implicitInteractionRetryTimeout) {
             do {
                 // Immediately bubble most failures, only retry if inconclusive.
-                try webDriver.send(request)
+                try await webDriver.send(request)
                 return .success(())
             } catch let error as ErrorResponse
                 where webDriver.isInconclusiveInteraction(error: error.status)
@@ -482,6 +490,11 @@ public final class Session {
     }
 
     deinit {
-        try? delete()  // Call `delete` directly to handle errors.
+        guard shouldDelete else { return }
+        let webDriver = self.webDriver
+        let sessionId = self.id
+        Task {
+            _ = try? await webDriver.send(Requests.SessionDelete(session: sessionId))
+        }
     }
 }

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -481,7 +481,7 @@ public final class Session {
                 try await webDriver.send(request)
                 return .success(())
             } catch let error as ErrorResponse
-                where webDriver.isInconclusiveInteraction(error: error.status)
+                where webDriver.isInconclusiveInteraction(error: error.status ?? .unknownError)
             {
                 // Return instead of throwing to indicate that `poll` can retry as needed.
                 return .failure(error)

--- a/Sources/WebDriver/Session.swift
+++ b/Sources/WebDriver/Session.swift
@@ -179,9 +179,13 @@ public final class Session {
         if let i = implicit { _implicitWaitTimeout = i }
     }
 
-    public func execute(script: String, args: [String] = [], async: Bool = false) async throws {
+    @discardableResult
+    public func execute<Result: Codable>(script: String, args: [String] = [], async: Bool = false)
+        async throws -> Result
+    {
         try await webDriver.send(
-            Requests.SessionScript(session: id, script: script, args: args, async: async))
+            Requests.SessionScript<Result>(session: id, script: script, args: args, async: async)
+        ).value
     }
 
     public func back() async throws {

--- a/Sources/WebDriver/TimeoutType.swift
+++ b/Sources/WebDriver/TimeoutType.swift
@@ -1,5 +1,0 @@
-public enum TimeoutType: String, Codable {
-    case script
-    case implicitWait = "implicit"
-    case pageLoad = "page load"
-}

--- a/Sources/WebDriver/URLRequestExtensions.swift
+++ b/Sources/WebDriver/URLRequestExtensions.swift
@@ -1,43 +1,17 @@
 import Foundation
+
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+    import FoundationNetworking
 #endif
 
-extension URLSession {
-    func dataTask(
-        with request: URLRequest,
-        _ completion: @escaping (Result<(Data, HTTPURLResponse), Error>) -> Void
-    )
-        -> URLSessionDataTask {
-        dataTask(with: request) { data, response, error in
-            if let error {
-                completion(.failure(error))
-            } else if let data, let response = response as? HTTPURLResponse {
-                completion(.success((data, response)))
-            } else {
-                fatalError("Unexpected result from URLSessionDataTask.")
-            }
-        }
-    }
-}
-
 extension URLRequest {
-    func send() throws -> (Int, Data) {
-        var result: Result<(Data, HTTPURLResponse), Error> =
-            .failure(NSError(domain: NSURLErrorDomain, code: URLError.unknown.rawValue))
-        let semaphore: DispatchSemaphore = .init(value: 0)
-        let task = URLSession.shared.dataTask(with: self) {
-            result = $0
-            semaphore.signal()
-        }
-        task.resume()
-        semaphore.wait()
+    func send() async throws -> (Int, Data) {
+        let (data, response) = try await URLSession.shared.data(for: self)
 
-        switch result {
-        case let .failure(error):
-            throw error
-        case let .success((data, response)):
-            return (statusCode: response.statusCode, data)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
         }
+
+        return (statusCode: httpResponse.statusCode, data)
     }
 }

--- a/Sources/WebDriver/WebDriver.swift
+++ b/Sources/WebDriver/WebDriver.swift
@@ -1,4 +1,4 @@
-public protocol WebDriver {
+public protocol WebDriver: Sendable {
     /// The protocol supported by the WebDriver server.
     var wireProtocol: WireProtocol { get }
 

--- a/Sources/WebDriver/WebDriver.swift
+++ b/Sources/WebDriver/WebDriver.swift
@@ -5,7 +5,7 @@ public protocol WebDriver: Sendable {
     /// Sends a WebDriver request to the server and returns the response.
     /// - Parameter request: The request to send.
     @discardableResult
-    func send<Req: Request>(_ request: Req) throws -> Req.Response
+    func send<Req: Request>(_ request: Req) async throws -> Req.Response
 
     /// Determines if a given error is inconclusive and should be retried.
     func isInconclusiveInteraction(error: ErrorResponse.Status) -> Bool
@@ -15,10 +15,10 @@ extension WebDriver {
     /// status - returns WinAppDriver status
     /// Returns: an instance of the WebDriverStatus type
     public var status: WebDriverStatus {
-        get throws {
+        get async throws {
             switch wireProtocol {
-                case .legacySelenium: return try send(Requests.LegacySelenium.Status())
-                case .w3c: return try send(Requests.W3C.Status()).value
+            case .legacySelenium: return try await send(Requests.LegacySelenium.Status())
+            case .w3c: return try await send(Requests.W3C.Status()).value
             }
         }
     }

--- a/Sources/WebDriver/Window.swift
+++ b/Sources/WebDriver/Window.swift
@@ -10,17 +10,21 @@ public struct Window {
     }
 
     public var position: (x: Double, y: Double) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.WindowPosition.Get(
-                session: session.id, windowHandle: handle)).value
+        get async throws {
+            let responseValue = try await webDriver.send(
+                Requests.WindowPosition.Get(
+                    session: session.id, windowHandle: handle)
+            ).value
             return (responseValue.x, responseValue.y)
         }
     }
 
     public var size: (width: Double, height: Double) {
-        get throws {
-            let responseValue = try webDriver.send(Requests.WindowSize.Get(
-                session: session.id, windowHandle: handle)).value
+        get async throws {
+            let responseValue = try await webDriver.send(
+                Requests.WindowSize.Get(
+                    session: session.id, windowHandle: handle)
+            ).value
             return (responseValue.width, responseValue.height)
         }
     }
@@ -28,19 +32,22 @@ public struct Window {
     /// - Parameters:
     ///   - width: The new window width
     ///   - height: The new window height
-    public func setSize(width: Double, height: Double) throws {
-        try webDriver.send(Requests.WindowSize.Post(session: session.id, windowHandle: handle, width: width, height: height))
+    public func setSize(width: Double, height: Double) async throws {
+        try await webDriver.send(
+            Requests.WindowSize.Post(
+                session: session.id, windowHandle: handle, width: width, height: height))
     }
 
     /// - Parameters:
     ///   - x: Position in the top left corner of the x coordinate
     ///   - y: Position in the top left corner of the y coordinate
-    public func setPosition(x: Double, y: Double) throws {
-        try webDriver.send(Requests.WindowPosition.Post(session: session.id, windowHandle: handle, x: x, y: y))
+    public func setPosition(x: Double, y: Double) async throws {
+        try await webDriver.send(
+            Requests.WindowPosition.Post(session: session.id, windowHandle: handle, x: x, y: y))
     }
 
     /// Maximize specific window if :windowHandle is "current" the current window will be maximized
-    public func maximize() throws {
-        try webDriver.send(Requests.WindowMaximize(session: session.id, windowHandle: handle))
+    public func maximize() async throws {
+        try await webDriver.send(Requests.WindowMaximize(session: session.id, windowHandle: handle))
     }
 }

--- a/Sources/WinAppDriver/WinAppDriver.swift
+++ b/Sources/WinAppDriver/WinAppDriver.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import WebDriver
 import WinSDK
@@ -25,14 +24,16 @@ public class WinAppDriver: WebDriver {
     private init(
         httpWebDriver: HTTPWebDriver,
         processTree: Win32ProcessTree? = nil,
-        childStdinHandle: HANDLE? = nil) {
+        childStdinHandle: HANDLE? = nil
+    ) {
         self.httpWebDriver = httpWebDriver
         self.processTree = processTree
         self.childStdinHandle = childStdinHandle
     }
 
     public static func attach(ip: String = defaultIp, port: Int = defaultPort) -> WinAppDriver {
-        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
+        let httpWebDriver = HTTPWebDriver(
+            endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
         return WinAppDriver(httpWebDriver: httpWebDriver)
     }
 
@@ -41,7 +42,8 @@ public class WinAppDriver: WebDriver {
         ip: String = defaultIp,
         port: Int = defaultPort,
         waitTime: TimeInterval? = defaultStartWaitTime,
-        outputFile: String? = nil) throws -> WinAppDriver {
+        outputFile: String? = nil
+    ) throws -> WinAppDriver {
         let processTree: Win32ProcessTree
         var childStdinHandle: HANDLE? = nil
         do {
@@ -93,10 +95,13 @@ public class WinAppDriver: WebDriver {
                 path: executablePath, args: [ip, String(port)], options: launchOptions)
         } catch let error as Win32Error {
             CloseHandle(childStdinHandle)
-            throw StartError(message: "Call to Win32 \(error.apiName) failed with error code \(error.errorCode).")
+            throw StartError(
+                message: "Call to Win32 \(error.apiName) failed with error code \(error.errorCode)."
+            )
         }
 
-        let httpWebDriver = HTTPWebDriver(endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
+        let httpWebDriver = HTTPWebDriver(
+            endpoint: URL(string: "http://\(ip):\(port)")!, wireProtocol: .legacySelenium)
 
         // Give WinAppDriver some time to start up
         if let waitTime {
@@ -104,7 +109,8 @@ public class WinAppDriver: WebDriver {
             Thread.sleep(forTimeInterval: waitTime)
 
             if let earlyExitCode = try? processTree.exitCode {
-                throw StartError(message: "WinAppDriver process exited early with error code \(earlyExitCode).")
+                throw StartError(
+                    message: "WinAppDriver process exited early with error code \(earlyExitCode).")
             }
         }
 
@@ -115,18 +121,19 @@ public class WinAppDriver: WebDriver {
     }
 
     deinit {
-        try? close() // Call close() directly to handle errors. 
+        try? close()  // Call close() directly to handle errors.
     }
 
     public var wireProtocol: WireProtocol { .legacySelenium }
 
     @discardableResult
-    public func send<Req: Request>(_ request: Req) throws -> Req.Response {
-        try httpWebDriver.send(request)
+    public func send<Req: Request>(_ request: Req) async throws -> Req.Response {
+        try await httpWebDriver.send(request)
     }
 
     public func isInconclusiveInteraction(error: ErrorResponse.Status) -> Bool {
-        error == .winAppDriver_elementNotInteractable || httpWebDriver.isInconclusiveInteraction(error: error)
+        error == .winAppDriver_elementNotInteractable
+            || httpWebDriver.isInconclusiveInteraction(error: error)
     }
 
     public func close() throws {

--- a/Tests/AppiumTests/AppiumTests.swift
+++ b/Tests/AppiumTests/AppiumTests.swift
@@ -7,24 +7,26 @@ final class AppiumTests: XCTestCase {
 
     override func setUpWithError() throws {
         super.setUp()
-        appiumServerURL = ProcessInfo.processInfo.environment["APPIUM_SERVER_URL"].flatMap { URL(string: $0) }
+        appiumServerURL = ProcessInfo.processInfo.environment["APPIUM_SERVER_URL"].flatMap {
+            URL(string: $0)
+        }
         try XCTSkipIf(appiumServerURL == nil, "APPIUM_SERVER_URL environment variable is not set.")
     }
 
-#if os(Windows)
-    func testAppium() throws {
-        let webDriver = HTTPWebDriver(endpoint: appiumServerURL!, wireProtocol: .w3c)
+    #if os(Windows)
+        func testAppium() async throws {
+            let webDriver = HTTPWebDriver(endpoint: appiumServerURL!, wireProtocol: .w3c)
 
-        let appiumOptions = Capabilities.AppiumOptions()
-        appiumOptions.automationName = "windows"
-        appiumOptions.app = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+            let appiumOptions = Capabilities.AppiumOptions()
+            appiumOptions.automationName = "windows"
+            appiumOptions.app = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
 
-        let capabilities = Capabilities()
-        capabilities.platformName = "windows"
-        capabilities.appiumOptions = appiumOptions
+            let capabilities = Capabilities()
+            capabilities.platformName = "windows"
+            capabilities.appiumOptions = appiumOptions
 
-        let session = try Session(webDriver: webDriver, capabilities: capabilities)
-        try session.sendKeys(.alt(.f4))
-    }
-#endif
+            let session = try await Session(webDriver: webDriver, capabilities: capabilities)
+            try await session.sendKeys(.alt(.f4))
+        }
+    #endif
 }

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -303,7 +303,7 @@ class APIToRequestMappingTests: XCTestCase {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
 
-        mockWebDriver.expect(path: "session/mySession/window_handle", method: .get, type: Requests.SessionWindowHandle.self) {
+        mockWebDriver.expect(path: "session/mySession/window", method: .get, type: Requests.SessionWindowHandle.self) {
             ResponseWithValue(.init("myWindow"))
         }
         XCTAssert(try session.windowHandle == "myWindow")
@@ -314,7 +314,7 @@ class APIToRequestMappingTests: XCTestCase {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         
-        mockWebDriver.expect(path: "session/mySession/window_handles", method: .get, type: Requests.SessionWindowHandles.self) {
+        mockWebDriver.expect(path: "session/mySession/window/handles", method: .get, type: Requests.SessionWindowHandles.self) {
             ResponseWithValue(.init(["myWindow", "myWindow"]))
         }
         XCTAssert(try session.windowHandles == ["myWindow", "myWindow"])

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -1,38 +1,45 @@
 import TestsCommon
+
 @testable import WebDriver
-import XCTest
 
 /// Tests how usage of high-level Session/Element APIs map to lower-level requests
-class APIToRequestMappingTests: XCTestCase {
+@MainActor
+final class APIToRequestMappingTests: XCTestCase {
     private typealias ResponseWithValue = Requests.ResponseWithValue
 
-    func testCreateSession() throws {
+    func testCreateSession() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
-        mockWebDriver.expect(path: "session", method: .post, type: Requests.LegacySelenium.Session.self) {
+        mockWebDriver.expect(
+            path: "session", method: .post, type: Requests.LegacySelenium.Session.self
+        ) {
             let capabilities = Capabilities()
             capabilities.platformName = "myPlatform"
-            return Requests.LegacySelenium.Session.Response(sessionId: "mySession", value: capabilities)
+            return Requests.LegacySelenium.Session.Response(
+                sessionId: "mySession", value: capabilities)
         }
-        let session = try Session(webDriver: mockWebDriver, capabilities: Capabilities())
+        let session = try await Session(webDriver: mockWebDriver, capabilities: Capabilities())
         XCTAssertEqual(session.id, "mySession")
         XCTAssertEqual(session.capabilities.platformName, "myPlatform")
 
         // Account for session deinitializer
         mockWebDriver.expect(path: "session/mySession", method: .delete)
+        try await session.delete()
     }
 
-    func testStatus_legacySelenium() throws {
+    func testStatus_legacySelenium() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
-        mockWebDriver.expect(path: "status", method: .get, type: Requests.LegacySelenium.Status.self) {
+        mockWebDriver.expect(
+            path: "status", method: .get, type: Requests.LegacySelenium.Status.self
+        ) {
             var status = WebDriverStatus()
             status.ready = true
             return status
         }
 
-        XCTAssertEqual(try mockWebDriver.status.ready, true)
+        XCTAssertEqual(try await mockWebDriver.status.ready, true)
     }
 
-    func testStatus_w3c() throws {
+    func testStatus_w3c() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .w3c)
         mockWebDriver.expect(path: "status", method: .get, type: Requests.W3C.Status.self) {
             var status = WebDriverStatus()
@@ -40,19 +47,19 @@ class APIToRequestMappingTests: XCTestCase {
             return Requests.W3C.Status.Response(status)
         }
 
-        XCTAssertEqual(try mockWebDriver.status.ready, true)
+        XCTAssertEqual(try await mockWebDriver.status.ready, true)
     }
 
-    func testSessionTitle() throws {
+    func testSessionTitle() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/title", method: .get) {
             ResponseWithValue("mySession.title")
         }
-        XCTAssertEqual(try session.title, "mySession.title")
+        XCTAssertEqual(try await session.title, "mySession.title")
     }
 
-    func testSessionScreenshot() throws {
+    func testSessionScreenshot() async throws {
         let base64TestImage: String =
             "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAHCAYAAAA1WQxeAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAB2GAAAdhgFdohOBAAAABmJLR0QA/wD/AP+gvaeTAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDIzLTA3LTEzVDIwOjAxOjQ1KzAwOjAwCWqxhgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyMy0wNy0xM1QyMDowMTo0NSswMDowMHg3CToAAAC2SURBVBhXY/iPDG7c+///5y8oBwJQFRj4/P9f3QNhn78Appi+fP3LkNfxnIFh43oGBiE+BoYjZxkYHj5iYFi2goHhzVsGpoePfjBMrrzLUNT4jIEh2IaBQZCTgaF1EgODkiIDg4gwA9iKpILL/xnkL/xnkLzyv8UUaIVL2P//Xz5DrGAAgoPzVjDosRxmaG4UZxArjAAa/YGBYfdxkBTEhP37bv9/+eIDWAcYHDsHNOEbkPH/PwCcrZANcnx9SAAAAABJRU5ErkJggg=="
 
@@ -61,303 +68,355 @@ class APIToRequestMappingTests: XCTestCase {
         mockWebDriver.expect(path: "session/mySession/screenshot", method: .get) {
             ResponseWithValue(base64TestImage)
         }
-        let data: Data = try session.screenshot()
+        let data: Data = try await session.screenshot()
         XCTAssert(isPNG(data: data))
     }
 
-    func testSessionFindElement() throws {
+    func testSessionFindElement() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        mockWebDriver.expect(path: "session/mySession/element", method: .post, type: Requests.SessionElement.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/element", method: .post, type: Requests.SessionElement.self
+        ) {
             XCTAssertEqual($0.using, "name")
             XCTAssertEqual($0.value, "myElement.name")
             return ResponseWithValue(.init(element: "myElement"))
         }
-        try session.findElement(locator: .name("myElement.name"))
+        _ = try await session.findElement(locator: .name("myElement.name"))
 
-        mockWebDriver.expect(path: "session/mySession/element/active", method: .post, type: Requests.SessionActiveElement.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/element/active", method: .post,
+            type: Requests.SessionActiveElement.self
+        ) {
             ResponseWithValue(.init(element: "myElement"))
         }
-        _ = try session.activeElement!
+        _ = try await session.activeElement!
     }
 
-    func testSessionMoveTo() throws {
+    func testSessionMoveTo() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
-        mockWebDriver.expect(path: "session/mySession/moveto", method: .post, type: Requests.SessionMoveTo.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/moveto", method: .post, type: Requests.SessionMoveTo.self
+        ) {
             XCTAssertEqual($0.element, "myElement")
             XCTAssertEqual($0.xOffset, 30)
             XCTAssertEqual($0.yOffset, 0)
             return CodableNone()
         }
-        try session.moveTo(element: element, xOffset: 30, yOffset: 0)
+        try await session.moveTo(element: element, xOffset: 30, yOffset: 0)
     }
 
-    func testSessionClick() throws {
+    func testSessionClick() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        mockWebDriver.expect(path: "session/mySession/click", method: .post, type: Requests.SessionButton.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/click", method: .post, type: Requests.SessionButton.self
+        ) {
             XCTAssertEqual($0.button, .left)
             return CodableNone()
         }
-        try session.click(button: .left)
+        try await session.click(button: .left)
     }
 
-    func testSessionButton() throws {
+    func testSessionButton() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        mockWebDriver.expect(path: "session/mySession/buttondown", method: .post, type: Requests.SessionButton.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/buttondown", method: .post, type: Requests.SessionButton.self
+        ) {
             XCTAssertEqual($0.button, .right)
             return CodableNone()
         }
-        try session.buttonDown(button: .right)
+        try await session.buttonDown(button: .right)
 
-        mockWebDriver.expect(path: "session/mySession/buttonup", method: .post, type: Requests.SessionButton.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/buttonup", method: .post, type: Requests.SessionButton.self
+        ) {
             XCTAssertEqual($0.button, .right)
             return CodableNone()
         }
-        try session.buttonUp(button: .right)
+        try await session.buttonUp(button: .right)
     }
- 
-    func testSessionOrientation() throws {
+
+    func testSessionOrientation() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/orientation", method: .post)
-        try session.setOrientation(.portrait)
+        try await session.setOrientation(.portrait)
 
-        mockWebDriver.expect(path: "session/mySession/orientation", method: .get, type: Requests.SessionOrientation.Get.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/orientation", method: .get,
+            type: Requests.SessionOrientation.Get.self
+        ) {
             ResponseWithValue(.portrait)
         }
-        XCTAssert(try session.orientation == .portrait)
+        XCTAssertEqual(try await session.orientation, .portrait)
 
         mockWebDriver.expect(path: "session/mySession/orientation", method: .post)
-        try session.setOrientation(.landscape)
+        try await session.setOrientation(.landscape)
 
-        mockWebDriver.expect(path: "session/mySession/orientation", method: .get, type: Requests.SessionOrientation.Get.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/orientation", method: .get,
+            type: Requests.SessionOrientation.Get.self
+        ) {
             ResponseWithValue(.landscape)
         }
-        XCTAssert(try session.orientation == .landscape)
+        XCTAssertEqual(try await session.orientation, .landscape)
     }
 
-    func testSendKeys() throws {
+    func testSendKeys() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
 
         let keys = Keys.sequence(.a, .b, .c)
-        mockWebDriver.expect(path: "session/mySession/keys", method: .post, type: Requests.SessionKeys.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/keys", method: .post, type: Requests.SessionKeys.self
+        ) {
             XCTAssertEqual($0.value.first, keys.rawValue)
             return CodableNone()
         }
-        try session.sendKeys(keys, releaseModifiers: false)
+        try await session.sendKeys(keys, releaseModifiers: false)
 
-        mockWebDriver.expect(path: "session/mySession/element/myElement/value", method: .post, type: Requests.ElementValue.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/element/myElement/value", method: .post,
+            type: Requests.ElementValue.self
+        ) {
             XCTAssertEqual($0.value.first, keys.rawValue)
             return CodableNone()
         }
-        try element.sendKeys(keys)
+        try await element.sendKeys(keys)
     }
 
-    func testElementText() throws {
+    func testElementText() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/text", method: .get) {
             ResponseWithValue("myElement.text")
         }
-        XCTAssertEqual(try element.text, "myElement.text")
+        XCTAssertEqual(try await element.text, "myElement.text")
     }
 
-    func testElementAttribute() throws {
+    func testElementAttribute() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
-        mockWebDriver.expect(path: "session/mySession/element/myElement/attribute/myAttribute.name", method: .get) {
+        mockWebDriver.expect(
+            path: "session/mySession/element/myElement/attribute/myAttribute.name", method: .get
+        ) {
             ResponseWithValue("myAttribute.value")
         }
-        XCTAssertEqual(try element.getAttribute(name: "myAttribute.name"), "myAttribute.value")
+        XCTAssertEqual(
+            try await element.getAttribute(name: "myAttribute.name"), "myAttribute.value")
     }
 
-    func testElementClick() throws {
+    func testElementClick() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/click", method: .post)
-        try element.click()
+        try await element.click()
     }
 
-    func testElementLocationAndSize() throws {
+    func testElementLocationAndSize() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
-        mockWebDriver.expect(path: "session/mySession/element/myElement/location", method: .get, type: Requests.ElementLocation.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/element/myElement/location", method: .get,
+            type: Requests.ElementLocation.self
+        ) {
             ResponseWithValue(.init(x: 10, y: -20))
         }
-        XCTAssert(try element.location == (x: 10, y: -20))
+        let location = try await element.location
+        XCTAssert(location == (x: 10, y: -20))
 
-        mockWebDriver.expect(path: "session/mySession/element/myElement/size", method: .get, type: Requests.ElementSize.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/element/myElement/size", method: .get,
+            type: Requests.ElementSize.self
+        ) {
             ResponseWithValue(.init(width: 100, height: 200))
         }
-        XCTAssert(try element.size == (width: 100, height: 200))
+        let size = try await element.size
+        XCTAssert(size == (width: 100, height: 200))
     }
 
-    func testElementEnabled() throws {
+    func testElementEnabled() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/enabled", method: .get) {
             ResponseWithValue(true)
         }
-        XCTAssert(try element.enabled == true)
+        XCTAssertEqual(try await element.enabled, true)
     }
 
-    func testElementSelected() throws {
+    func testElementSelected() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/element/myElement/selected", method: .get) {
             ResponseWithValue(true)
         }
-        XCTAssert(try element.selected == true)
+        XCTAssertEqual(try await element.selected, true)
     }
 
-    func testWindowPosition() throws {
+    func testWindowPosition() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/position", method: .post)
-        try session.window(handle: "myWindow").setPosition(x: 9, y: 16)
+        try await session.window(handle: "myWindow").setPosition(x: 9, y: 16)
 
-        mockWebDriver.expect(path: "session/mySession/window/myWindow/position", method: .get, type: Requests.WindowPosition.Get.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/window/myWindow/position", method: .get,
+            type: Requests.WindowPosition.Get.self
+        ) {
             ResponseWithValue(.init(x: 9, y: 16))
         }
-        XCTAssert(try session.window(handle: "myWindow").position == (x: 9, y: 16))
+        let position = try await session.window(handle: "myWindow").position
+        XCTAssert(position == (x: 9, y: 16))
     }
 
-    func testSessionScript() throws {
+    func testSessionScript() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/execute", method: .post)
-        XCTAssertNotNil(try session.execute(script: "return document.body", args: ["script"], async: false))
+        try await session.execute(script: "return document.body", args: ["script"], async: false)
     }
 
-    func testSessionScriptAsync() throws {
+    func testSessionScriptAsync() async throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/execute/async", method: .post)
-        XCTAssertNotNil(try session.execute(script: "return document.body", args: ["script"], async: true))
+        try await session.execute(script: "return document.body", args: ["script"], async: true)
     }
 
-    func testSessionTouchScroll() throws {
+    func testSessionTouchScroll() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/scroll", method: .post)
-        try session.touchScroll(element: element, xOffset: 9, yOffset: 16)
+        try await session.touchScroll(element: element, xOffset: 9, yOffset: 16)
     }
 
-    func testWindow() throws {
+    func testWindow() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window", method: .post)
-        try session.focus(window: "myWindow")
+        try await session.focus(window: "myWindow")
 
         mockWebDriver.expect(path: "session/mySession/window", method: .delete)
-        try session.close(window: "myWindow")
+        try await session.close(window: "myWindow")
     }
 
-    func testWindowHandleSize() throws {
+    func testWindowHandleSize() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/size", method: .post)
-        try session.window(handle: "myWindow").setSize(width: 500, height: 500)
+        try await session.window(handle: "myWindow").setSize(width: 500, height: 500)
 
-        mockWebDriver.expect(path: "session/mySession/window/myWindow/size", method: .get, type: Requests.WindowSize.Get.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/window/myWindow/size", method: .get,
+            type: Requests.WindowSize.Get.self
+        ) {
             ResponseWithValue(.init(width: 500, height: 500))
         }
-        XCTAssert(try session.window(handle: "myWindow").size == (width: 500, height: 500))
+        let size = try await session.window(handle: "myWindow").size
+        XCTAssert(size == (width: 500, height: 500))
     }
 
-    func testLocation() throws {
+    func testLocation() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let location = Location(latitude: 5, longitude: 20, altitude: 2003)
-        
+
         mockWebDriver.expect(path: "session/mySession/location", method: .post)
-        try session.setLocation(location)
-        
-        mockWebDriver.expect(path: "session/mySession/location", method: .get, type: Requests.SessionLocation.Get.self) {
+        try await session.setLocation(location)
+
+        mockWebDriver.expect(
+            path: "session/mySession/location", method: .get,
+            type: Requests.SessionLocation.Get.self
+        ) {
             ResponseWithValue(.init(latitude: 5, longitude: 20, altitude: 2003))
         }
-        XCTAssert(try session.location == location)
+        XCTAssertEqual(try await session.location, location)
     }
 
-    func testMaximizeWindow() throws {
+    func testMaximizeWindow() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session: Session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/window/myWindow/maximize", method: .post)
-        try session.window(handle: "myWindow").maximize()
+        try await session.window(handle: "myWindow").maximize()
     }
 
-    func testWindowHandle() throws {
+    func testWindowHandle() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
 
-        mockWebDriver.expect(path: "session/mySession/window", method: .get, type: Requests.SessionWindowHandle.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/window", method: .get, type: Requests.SessionWindowHandle.self
+        ) {
             ResponseWithValue(.init("myWindow"))
         }
-        XCTAssert(try session.windowHandle == "myWindow")
+        XCTAssertEqual(try await session.windowHandle, "myWindow")
     }
 
-    func testWindowHandles() throws {
+    func testWindowHandles() async throws {
 
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        
-        mockWebDriver.expect(path: "session/mySession/window/handles", method: .get, type: Requests.SessionWindowHandles.self) {
+
+        mockWebDriver.expect(
+            path: "session/mySession/window/handles", method: .get,
+            type: Requests.SessionWindowHandles.self
+        ) {
             ResponseWithValue(.init(["myWindow", "myWindow"]))
         }
-        XCTAssert(try session.windowHandles == ["myWindow", "myWindow"])
+        XCTAssertEqual(try await session.windowHandles, ["myWindow", "myWindow"])
     }
 
-
-    func testElementDoubleClick() throws {
+    func testElementDoubleClick() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/doubleclick", method: .post)
-        XCTAssertNotNil(try element.doubleClick())
+        try await element.doubleClick()
     }
 
-    func testElementFlick() throws {
+    func testElementFlick() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         let element = Element(session: session, id: "myElement")
         mockWebDriver.expect(path: "session/mySession/touch/flick", method: .post)
-        XCTAssertNotNil(try element.flick(xOffset: 5, yOffset: 20, speed: 2003))
+        try await element.flick(xOffset: 5, yOffset: 20, speed: 2003)
     }
 
-    func testSessionFlick() throws {
+    func testSessionFlick() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/touch/flick", method: .post)
-        XCTAssertNotNil(try session.flick(xSpeed: 5, ySpeed: 20))
+        try await session.flick(xSpeed: 5, ySpeed: 20)
     }
 
-    func testSessionSource() throws {
+    func testSessionSource() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        mockWebDriver.expect(path: "session/mySession/source", method: .get, type: Requests.SessionSource.self) {
+        mockWebDriver.expect(
+            path: "session/mySession/source", method: .get, type: Requests.SessionSource.self
+        ) {
             ResponseWithValue("currentSource")
         }
-        XCTAssert(try session.source == "currentSource")
+        XCTAssertEqual(try await session.source, "currentSource")
     }
 
-    func testSessionTimeouts() throws {
+    func testSessionTimeouts() async throws {
         let mockWebDriver: MockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
         mockWebDriver.expect(path: "session/mySession/timeouts", method: .post)
-        try session.setTimeout(type: .implicitWait, duration: 5)
+        try await session.setTimeout(implicit: 5)
         XCTAssert(session.implicitWaitTimeout == 5.0)
     }
 }

--- a/Tests/UnitTests/APIToRequestMappingTests.swift
+++ b/Tests/UnitTests/APIToRequestMappingTests.swift
@@ -244,7 +244,7 @@ class APIToRequestMappingTests: XCTestCase {
     func testSessionScriptAsync() throws {
         let mockWebDriver = MockWebDriver(wireProtocol: .legacySelenium)
         let session = Session(webDriver: mockWebDriver, existingId: "mySession")
-        mockWebDriver.expect(path: "session/mySession/execute_async", method: .post)
+        mockWebDriver.expect(path: "session/mySession/execute/async", method: .post)
         XCTAssertNotNil(try session.execute(script: "return document.body", args: ["script"], async: true))
     }
 

--- a/Tests/UnitTests/MockWebDriver.swift
+++ b/Tests/UnitTests/MockWebDriver.swift
@@ -1,5 +1,6 @@
-@testable import WebDriver
 import XCTest
+
+@testable import WebDriver
 
 /// A mock WebDriver implementation which can be configured
 /// to expect certain requests and fail if they don't match.
@@ -26,25 +27,33 @@ class MockWebDriver: WebDriver {
 
     /// Queues an expected request and specifies its response handler.
     /// This overload is the most generic for any incoming body type and outgoing response type.
-    func expect<ReqBody: Codable, Res: Codable>(path: String, method: HTTPMethod, handler: @escaping (ReqBody) throws -> Res) {
-        expectations.append(Expectation(path: path, method: method, handler: {
-            let requestBody: ReqBody
-            if let requestBodyData = $0 {
-                requestBody = try JSONDecoder().decode(ReqBody.self, from: requestBodyData)
-            } else if ReqBody.self == CodableNone.self {
-                requestBody = CodableNone() as Any as! ReqBody
-            } else {
-                throw UnexpectedRequestBodyError()
-            }
+    func expect<ReqBody: Codable, Res: Codable>(
+        path: String, method: HTTPMethod, handler: @escaping (ReqBody) throws -> Res
+    ) {
+        expectations.append(
+            Expectation(
+                path: path, method: method,
+                handler: {
+                    let requestBody: ReqBody
+                    if let requestBodyData = $0 {
+                        requestBody = try JSONDecoder().decode(ReqBody.self, from: requestBodyData)
+                    } else if ReqBody.self == CodableNone.self {
+                        requestBody = CodableNone() as Any as! ReqBody
+                    } else {
+                        throw UnexpectedRequestBodyError()
+                    }
 
-            let response = try handler(requestBody)
-            return Res.self == CodableNone.self ? nil : try JSONEncoder().encode(response)
-        }))
+                    let response = try handler(requestBody)
+                    return Res.self == CodableNone.self ? nil : try JSONEncoder().encode(response)
+                }))
     }
 
     /// Queues an expected request and specifies its response handler.
     /// This overload uses a Request.Type for easier type inference.
-    func expect<Req: Request>(path: String, method: HTTPMethod, type: Req.Type, handler: @escaping (Req.Body) throws -> Req.Response) {
+    func expect<Req: Request>(
+        path: String, method: HTTPMethod, type: Req.Type,
+        handler: @escaping (Req.Body) throws -> Req.Response
+    ) {
         expect(path: path, method: method) {
             (requestBody: Req.Body) -> Req.Response in try handler(requestBody)
         }
@@ -52,7 +61,10 @@ class MockWebDriver: WebDriver {
 
     /// Queues an expected request and specifies its response handler and outoing response type.
     /// This overload ignores the incoming request body.
-    func expect<Req: Request>(path: String, method: HTTPMethod, type: Req.Type, handler: @escaping () throws -> Req.Response) {
+    func expect<Req: Request>(
+        path: String, method: HTTPMethod, type: Req.Type,
+        handler: @escaping () throws -> Req.Response
+    ) {
         expect(path: path, method: method) {
             () -> Req.Response in try handler()
         }
@@ -60,7 +72,8 @@ class MockWebDriver: WebDriver {
 
     /// Queues an expected request and specifies its response handler.
     /// This overload ignores the incoming request body.
-    func expect<Res: Codable>(path: String, method: HTTPMethod, handler: @escaping () throws -> Res) {
+    func expect<Res: Codable>(path: String, method: HTTPMethod, handler: @escaping () throws -> Res)
+    {
         expect(path: path, method: method) { (_: CodableNone) -> Res in try handler() }
     }
 
@@ -73,14 +86,15 @@ class MockWebDriver: WebDriver {
     }
 
     @discardableResult
-    func send<Req: Request>(_ request: Req) throws -> Req.Response {
+    func send<Req: Request>(_ request: Req) async throws -> Req.Response {
         XCTAssertNotEqual(expectations.count, 0)
 
         let expectation = expectations.remove(at: 0)
         XCTAssertEqual(request.pathComponents.joined(separator: "/"), expectation.path)
         XCTAssertEqual(request.method, expectation.method)
 
-        let requestBody: Data? = Req.Body.self == CodableNone.self
+        let requestBody: Data? =
+            Req.Body.self == CodableNone.self
             ? nil : try JSONEncoder().encode(request.body)
 
         let responseData = try expectation.handler(requestBody)


### PR DESCRIPTION
Hi,

`Sources/WebDriver/Requests.swift` incorrectly has `ELEMENT` as the web element identifier.

The W3C web element identifier [should instead be the string constant `element-6066-11e4-a52e-4f735466cecf`](https://www.w3.org/TR/webdriver/#elements).

This PR simply updates the web element identifier from `ELEMENT` to `element-6066-11e4-a52e-4f735466cecf`.

(Thanks to [this guide to the W3C WebDriver Spec](https://github.com/jlipps/simple-wd-spec?tab=readme-ov-file#find-element))