### PR TITLE
docs: document protocol detection

### DIFF
--- a/Docs/SupportedAPIs.md
+++ b/Docs/SupportedAPIs.md
@@ -3,6 +3,9 @@
 This table shows a mapping between WebDriver commands, backend support (currently just WinAppDriver), and the
 swift-webdriver API that implements the given command.
 
+`GET /status` is implemented for both Selenium legacy JSON wire protocol and W3C WebDriver response shapes.
+`HTTPWebDriver.createWithDetectedProtocol(serverURL:)` uses that endpoint to detect which wire protocol an HTTP endpoint speaks before any session is created.
+
 Contributions to expand support to unimplemented functionality are always welcome.
 
 | Method | Command Path                                        | WinAppDriver | swift-webdriver API |

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,25 @@ Build and run tests using `swift build` and `swift test`, or use the [Swift exte
 
 For additional examples, refer to the `Tests\WebDriverTests` directory.
 
+### Protocol selection
+
+If you already know which wire protocol your endpoint speaks, construct the HTTP driver explicitly:
+
+```swift
+let webDriver = HTTPWebDriver(
+    endpoint: URL(string: "http://127.0.0.1:4723")!,
+    wireProtocol: .w3c)
+```
+
+If the endpoint may be either Selenium legacy JSON wire protocol or W3C WebDriver, let the library probe `GET /status` and choose the matching response shape:
+
+```swift
+let webDriver = try HTTPWebDriver.createWithDetectedProtocol(
+    serverURL: URL(string: "http://127.0.0.1:4723")!)
+```
+
+This only detects the protocol; it does not create a session. Appium endpoints are typically W3C, while older WinAppDriver setups may use the legacy Selenium response format.
+
 ### CMake
 
 To build with CMake, use the Ninja generator:


### PR DESCRIPTION
## Summary
- document explicit W3C/legacy wire protocol selection for `HTTPWebDriver`
- document `HTTPWebDriver.createWithDetectedProtocol(serverURL:)` and its `GET /status` probe behavior
- note in the supported API matrix that `/status` supports both legacy Selenium and W3C response shapes

## Context
While reviewing the open W3C/Appium-related issues, I noticed that W3C `/status` support and protocol detection are already implemented in `Requests.W3C.Status`, `WebDriver.status`, and `HTTPWebDriver.detectProtocol`. This PR makes that existing behavior discoverable from the README and supported API docs.

## Testing
- `git diff --check`
- `swift build`
